### PR TITLE
Support .oga file extension

### DIFF
--- a/src/source/ogg_loader.rs
+++ b/src/source/ogg_loader.rs
@@ -65,6 +65,6 @@ impl AssetLoader for OggLoader {
     }
 
     fn extensions(&self) -> &[&str] {
-        &["ogg"]
+        &["ogg", "oga"]
     }
 }

--- a/src/source/ogg_loader.rs
+++ b/src/source/ogg_loader.rs
@@ -65,6 +65,6 @@ impl AssetLoader for OggLoader {
     }
 
     fn extensions(&self) -> &[&str] {
-        &["ogg", "oga"]
+        &["ogg", "oga", "spx"]
     }
 }


### PR DESCRIPTION
I purchased some OGG files from soundimage.org, and they come with the `.oga` extension.  According to [the wikipedia page](https://en.wikipedia.org/wiki/Ogg) it is one of several possible extensions.

With this change, I can load my files without having to rename them (it works great in my testing).  What do you think?