### PR TITLE
Cleanup stopped instances.

### DIFF
--- a/src/audio_output.rs
+++ b/src/audio_output.rs
@@ -298,6 +298,12 @@ impl AudioOutput {
         }
     }
 
+    pub(crate) fn cleanup_stopped_instances(&mut self) {
+        for (_, instances) in self.instances.iter_mut() {
+            instances.retain(|instance| instance.state() != InstanceState::Stopped);
+        }
+    }
+
     fn start_stream<T: kira::audio_stream::AudioStream>(
         &mut self,
         stream: T,
@@ -365,6 +371,7 @@ pub fn play_queued_audio_system(world: &mut World) {
     let mut audio = world.get_resource_mut::<Audio>().unwrap();
     if let Some(audio_sources) = world.get_resource::<Assets<AudioSource>>() {
         audio_output.run_queued_audio_commands(&*audio_sources, &mut *audio);
+        audio_output.cleanup_stopped_instances();
     };
 }
 


### PR DESCRIPTION
After playing the sound in one channel for too many times, when setting volume to the channel, I got an `Failed to set volume for instance: CommandQueueFull` error, and then if a new sound was played, I got a panic `Failed to add sound to the AudioManager`.
The cause is that there are too many instances in the channel, most of which have been stopped. This patch removes stopped instances every time `run_queued_audio_commands()` is run.