### PR TITLE
feat: public AudioSource member

### DIFF
--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -17,5 +17,5 @@ pub use wav_loader::WavLoader;
 #[derive(Debug, Clone, TypeUuid)]
 #[uuid = "6a9fc4ca-b5b5-94d6-613c-522e2d9fe86d"]
 pub struct AudioSource {
-    pub(crate) sound: Sound,
+    pub sound: Sound,
 }


### PR DESCRIPTION
I have a scenario where I want to load an audio source from a packed asset binary. In order to do that, I would need to create a custom AudioSource and be able to access the `sound` member.