### PR TITLE
Update to bevy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wav = ["kira/wav"]
 
 [dependencies]
 # bevy
-bevy = { version = "0.6", default-features = false }
+bevy = { version = "0.7", default-features = false }
 
 # other
 anyhow = "1.0"


### PR DESCRIPTION

This PR updates the bevy dependency to 0.7.. We might want to update Kira as well, but that's up to you, i am prepared to do so in this PR, in a new one, or we might postpone it.