### PR TITLE
Fix links in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,12 +2,12 @@
 
 These examples are simple Bevy Apps illustrating the capabilities of `bevy_kira_audio`. Run the examples with `cargo run --example <example>`.
 
-| Example                                         | Description                                                          |
-|-------------------------------------------------|----------------------------------------------------------------------|
-| [`basic.rs`](/basic.rs)                         | Display of basic functionality                                       |
-| [`custom_channel.rs`](/custom_channel.rs)       | How to add and use a custom audio channel                            |
-| [`multiple_channels.rs`](/multiple_channels.rs) | GUI application with full control over tree different audio channels |
-| [`status.rs`](/status.rs)                       | Continuously get the playback state of a sound                       |
+| Example                                                  | Description                                                          |
+| -------------------------------------------------------- | -------------------------------------------------------------------- |
+| [`basic.rs`](/examples/basic.rs)                         | Display of basic functionality                                       |
+| [`custom_channel.rs`](/examples/custom_channel.rs)       | How to add and use a custom audio channel                            |
+| [`multiple_channels.rs`](/examples/multiple_channels.rs) | GUI application with full control over tree different audio channels |
+| [`status.rs`](/examples/status.rs)                       | Continuously get the playback state of a sound                       |
 
 ## Credits
 The examples include assets with copyright:


### PR DESCRIPTION
The links were pointing to the root, which lead to 404 when clicking.