### PR TITLE
Remove contains_key assertion on get_channel for dynamic channels

### DIFF
--- a/src/channel/dynamic.rs
+++ b/src/channel/dynamic.rs
@@ -223,11 +223,6 @@ impl DynamicAudioChannels {
 
     /// Get a channel to play and control audio in
     pub fn get_channel(&self, key: &str) -> Option<&DynamicAudioChannel> {
-        assert!(
-            self.channels.contains_key(key),
-            "Attempting to access dynamic audio channel '{:?}', which doesn't exist.",
-            key
-        );
         self.channels.get(key)
     }
 }


### PR DESCRIPTION
This PR addresses the fact that `get_channel()` will panic instead of returning `None` when no dynamic channel of such name is found, due to the presence of an assertion.

The fix is to remove the assertion.
