### PR TITLE
Implement systems for common channel actions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod backend_settings;
 mod channel;
 mod instance;
 mod source;
+mod systems;
 
 pub use audio::{
     AudioApp, AudioEasing, AudioTween, FadeIn, FadeOut, PlayAudioCommand, PlaybackState,
@@ -48,6 +49,7 @@ pub use audio::{
 pub use backend_settings::AudioSettings;
 pub use channel::AudioControl;
 pub use source::AudioSource;
+pub use systems::{pause_playback, resume_playback, stop_playback};
 
 /// Most commonly used types
 pub mod prelude {
@@ -70,6 +72,8 @@ pub mod prelude {
     pub use crate::source::AudioSource;
     #[doc(hidden)]
     pub use crate::{Audio, AudioPlugin, MainTrack};
+    #[doc(hidden)]
+    pub use crate::{pause_playback, resume_playback, stop_playback};
 }
 
 use crate::audio_output::{cleanup_stopped_instances, play_dynamic_channels, AudioOutput};

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,0 +1,29 @@
+//! Systems for performing common simple actions.
+
+use crate::{AudioControl, AudioChannel};
+use bevy::prelude::Res;
+use std::marker::{Send, Sync};
+
+/// Stop the playback of the given channel.
+pub fn stop_playback<T>(channel: Res<AudioChannel<T>>)
+where
+    T: Send + Sync + 'static,
+{
+    channel.stop();
+}
+
+/// Pause the playback of the given channel.
+pub fn pause_playback<T>(channel: Res<AudioChannel<T>>)
+where
+    T: Send + Sync + 'static,
+{
+    channel.pause();
+}
+
+/// Resume the playback of the given channel.
+pub fn resume_playback<T>(channel: Res<AudioChannel<T>>)
+where
+    T: Send + Sync + 'static,
+{
+    channel.resume();
+}


### PR DESCRIPTION
It is common to want to do something simple like stop the playback of a channel on entering or exiting a certain state. This PR removes boilerplate from this functionality. E.g. (using [iyes_loopless](https://github.com/IyesGames/iyes_loopless)):

Old version:
```rust
impl Plugin for FooPlugin {
    fn build(&self, app: &mut App) {
        app.add_exit_system(GameState::MainMenu, stop_title_music);
    }
}

fn stop_title_music(audio: Res<AudioChannel<BgmChannel>>) {
    audio.stop();
}
```

With PR changes:
```rust
impl Plugin for FooPlugin {
    fn build(&self, app: &mut App) {
        app.add_exit_system(GameState::MainMenu, stop_playback::<BgmChannel>);
    }
}
```