### PR TITLE
check if receiver exists before updating

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub use audio::{
 pub use backend_settings::AudioSettings;
 pub use channel::AudioControl;
 pub use source::AudioSource;
+use spacial::cleanup_stopped_spacial_instances;
 
 /// Most commonly used types
 pub mod prelude {
@@ -169,6 +170,12 @@ impl Plugin for AudioPlugin {
             .add_system(
                 run_spacial_audio
                     .in_base_set(CoreSet::PostUpdate)
+                    .run_if(resource_exists::<SpacialAudio>()),
+            )
+            .add_system(
+                cleanup_stopped_spacial_instances
+                    .in_base_set(CoreSet::PreUpdate)
+                    .in_set(AudioSystemSet::InstanceCleanup)
                     .run_if(resource_exists::<SpacialAudio>()),
             );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,14 +168,14 @@ impl Plugin for AudioPlugin {
             )
             .add_audio_channel::<MainTrack>()
             .add_system(
-                run_spacial_audio
-                    .in_base_set(CoreSet::PostUpdate)
-                    .run_if(resource_exists::<SpacialAudio>()),
-            )
-            .add_system(
                 cleanup_stopped_spacial_instances
                     .in_base_set(CoreSet::PreUpdate)
                     .in_set(AudioSystemSet::InstanceCleanup)
+                    .run_if(resource_exists::<SpacialAudio>()),
+            )
+            .add_system(
+                run_spacial_audio
+                    .in_base_set(CoreSet::PostUpdate)
                     .run_if(resource_exists::<SpacialAudio>()),
             );
     }

--- a/src/spacial.rs
+++ b/src/spacial.rs
@@ -68,3 +68,20 @@ pub(crate) fn run_spacial_audio(
         spacial_audio.update(receiver_transform, &emitters, &mut audio_instances);
     }
 }
+
+pub(crate) fn cleanup_stopped_spacial_instances(
+    mut emitters: Query<&mut AudioEmitter>,
+    instances: ResMut<Assets<AudioInstance>>,
+) {
+    for mut emitter in emitters.iter_mut() {
+        let handles = &mut emitter.instances;
+
+        handles.retain(|handle| {
+            if let Some(instance) = instances.get(handle) {
+                instance.handle.state() != kira::sound::static_sound::PlaybackState::Stopped
+            } else {
+                false
+            }
+        });
+    }
+}

--- a/src/spacial.rs
+++ b/src/spacial.rs
@@ -64,6 +64,7 @@ pub(crate) fn run_spacial_audio(
     emitters: Query<(&GlobalTransform, &AudioEmitter)>,
     mut audio_instances: ResMut<Assets<AudioInstance>>,
 ) {
-    let receiver_transform = receiver.single();
-    spacial_audio.update(receiver_transform, &emitters, &mut audio_instances);
+    if let Ok(receiver_transform) = receiver.get_single() {
+        spacial_audio.update(receiver_transform, &emitters, &mut audio_instances);
+    }
 }


### PR DESCRIPTION
When using spatial audio, it's possible that a component with AudioReceiver is not immediately available which results in a crash.