### PR TITLE
Update to bevy v0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_kira_audio"
-version = "0.16.0-dev"
+version = "0.17.0"
 authors = ["Niklas Eicker <hello@nikl.me>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ wav = ["kira/wav"]
 settings_loader = ["dep:ron", "dep:serde", "kira/serde"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = ["bevy_asset"] }
+bevy = { version = "0.11", default-features = false, features = ["bevy_asset"] }
 anyhow = "1.0"
 kira = { version = "0.8", default-features = false, features = ["cpal"] }
 ron = { version = "0.8", optional = true }
@@ -31,7 +31,7 @@ parking_lot = "0.12"
 thiserror = "1.0"
 
 [dev-dependencies.bevy]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = [
     "bevy_asset",

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ use bevy::prelude::*;
 
 fn main() {
    App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
-        .add_system(start_background_audio.on_startup())
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, start_background_audio)
         .run();
 }
 
@@ -91,7 +90,8 @@ The main branch is compatible with the latest Bevy release.
 Compatibility of `bevy_kira_audio` versions:
 | `bevy_kira_audio` | `bevy`  |
 |  :--              |  :--    |
-| `0.15`            | `0.10`  |
+| `0.17`            | `0.11`  |
+| `0.15` - `0.16`   | `0.10`  |
 | `0.13` - `0.14`   | `0.9`   |
 | `0.11` - `0.12`   | `0.8`   |
 | `0.9` - `0.10`    | `0.7`   |

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,9 +3,8 @@ use bevy_kira_audio::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
-        .add_system(play_loop.on_startup())
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, play_loop)
         .run()
 }
 

--- a/examples/channel_control.rs
+++ b/examples/channel_control.rs
@@ -7,10 +7,9 @@ use bevy_kira_audio::prelude::*;
 // Right-click to resume the audio
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
-        .add_system(play_loop.on_startup())
-        .add_system(channel_control)
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, play_loop)
+        .add_systems(Update, channel_control)
         .run()
 }
 

--- a/examples/custom_channel.rs
+++ b/examples/custom_channel.rs
@@ -3,11 +3,10 @@ use bevy_kira_audio::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
+        .add_plugins((DefaultPlugins, AudioPlugin))
         // add our custom audio channel
         .add_audio_channel::<Background>()
-        .add_system(play.on_startup())
+        .add_systems(Startup, play)
         .run();
 }
 

--- a/examples/dynamic_channels.rs
+++ b/examples/dynamic_channels.rs
@@ -5,10 +5,9 @@ use bevy_kira_audio::prelude::*;
 /// that is not known at compile time, you can create and use dynamic channels based on string keys.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
-        .add_system(start_background_audio.on_startup())
-        .add_system(plop)
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, start_background_audio)
+        .add_systems(Update, plop)
         .run()
 }
 

--- a/examples/instance_control.rs
+++ b/examples/instance_control.rs
@@ -6,10 +6,9 @@ use bevy_kira_audio::prelude::*;
 // sent to the audio thread immediately.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
-        .add_system(play_loop.on_startup())
-        .add_system(instance_control)
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, play_loop)
+        .add_systems(Update, instance_control)
         .run()
 }
 

--- a/examples/multiple_channels.rs
+++ b/examples/multiple_channels.rs
@@ -8,13 +8,17 @@ use std::marker::PhantomData;
 // This is a bigger example with a GUI for full control over three audio channels
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
+        .add_plugins((DefaultPlugins, AudioPlugin))
         .init_resource::<LastAction>()
-        .add_system(prepare_audio_and_ui.on_startup())
-        .add_systems(create_row_systems::<FirstChannel>())
-        .add_systems(create_row_systems::<SecondChannel>())
-        .add_systems(create_row_systems::<ThirdChannel>())
+        .add_systems(Startup, prepare_audio_and_ui)
+        .add_systems(
+            Update,
+            (
+                create_row_systems::<FirstChannel>(),
+                create_row_systems::<SecondChannel>(),
+                create_row_systems::<ThirdChannel>(),
+            ),
+        )
         .add_audio_channel::<FirstChannel>()
         .add_audio_channel::<SecondChannel>()
         .add_audio_channel::<ThirdChannel>()
@@ -57,7 +61,7 @@ fn play_pause_button<T: Component + Default>(
     if channel_state.stopped {
         return;
     }
-    if interaction == &Interaction::Clicked {
+    if interaction == &Interaction::Pressed {
         if !last_action.action(&time) {
             return;
         }
@@ -88,7 +92,7 @@ fn stop_button<T: Component + Default>(
     if channel_state.stopped {
         return;
     }
-    if interaction == &Interaction::Clicked {
+    if interaction == &Interaction::Pressed {
         if !last_action.action(&time) {
             return;
         }
@@ -118,7 +122,7 @@ fn loop_button<T: Component + Default>(
     if channel_state.loop_started {
         return;
     }
-    if interaction == &Interaction::Clicked {
+    if interaction == &Interaction::Pressed {
         if !last_action.action(&time) {
             return;
         }
@@ -142,7 +146,7 @@ fn play_sound_button<T: Component + Default>(
     } else {
         NORMAL_BUTTON.into()
     };
-    if interaction == &Interaction::Clicked {
+    if interaction == &Interaction::Pressed {
         if !last_action.action(&time) {
             return;
         }
@@ -165,7 +169,7 @@ fn volume_buttons<T: Component + Default>(
         } else {
             NORMAL_BUTTON.into()
         };
-        if interaction == &Interaction::Clicked {
+        if interaction == &Interaction::Pressed {
             if !last_action.action(&time) {
                 return;
             }
@@ -280,7 +284,8 @@ fn set_up_ui(commands: &mut Commands, asset_server: ResMut<AssetServer>) {
             style: Style {
                 display: Display::Flex,
                 flex_direction: FlexDirection::Column,
-                size: Size::new(Val::Percent(100.), Val::Percent(100.)),
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
                 ..Default::default()
             },
             ..Default::default()
@@ -302,7 +307,8 @@ fn build_button_row<T: Component + Default + Clone>(
             style: Style {
                 display: Display::Flex,
                 flex_direction: FlexDirection::Row,
-                size: Size::new(Val::Percent(100.), Val::Percent(33.3)),
+                width: Val::Percent(100.0),
+                height: Val::Percent(33.3),
                 ..Default::default()
             },
             ..Default::default()
@@ -311,7 +317,8 @@ fn build_button_row<T: Component + Default + Clone>(
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        size: Size::new(Val::Px(120.0), Val::Percent(100.)),
+                        width: Val::Px(120.0),
+                        height: Val::Percent(100.0),
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
                         ..Default::default()
@@ -395,7 +402,8 @@ fn spawn_button<T: Component + Clone>(
     parent
         .spawn(ButtonBundle {
             style: Style {
-                size: Size::new(Val::Px(100.0), Val::Px(65.0)),
+                width: Val::Px(100.0),
+                height: Val::Px(65.0),
                 margin: UiRect::all(Val::Auto),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -5,9 +5,8 @@ use std::time::Duration;
 /// This example shows the different settings that can be applied when playing a sound.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
-        .add_system(play_audio.on_startup())
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, play_audio)
         .run();
 }
 

--- a/examples/settings_loader.rs
+++ b/examples/settings_loader.rs
@@ -5,9 +5,8 @@ use bevy_kira_audio::prelude::*;
 /// You can also easily apply settings when playing a sound (see the `settings` example).
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
-        .add_system(play_audio.on_startup())
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, play_audio)
         .run();
 }
 

--- a/examples/spacial.rs
+++ b/examples/spacial.rs
@@ -8,10 +8,8 @@ fn main() {
     App::new()
         .insert_resource(Msaa::Off)
         .insert_resource(SpacialAudio { max_distance: 25. })
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
-        .add_plugin(CameraPlugin)
-        .add_system(setup.on_startup())
+        .add_plugins((DefaultPlugins, AudioPlugin, CameraPlugin))
+        .add_systems(Startup, setup)
         .run()
 }
 
@@ -120,10 +118,8 @@ pub struct FlyCam;
 impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<InputState>()
-            .add_system(initial_grab_cursor.on_startup())
-            .add_system(player_move)
-            .add_system(player_look)
-            .add_system(cursor_grab);
+            .add_systems(Startup, initial_grab_cursor)
+            .add_systems(Update, (player_move, player_look, cursor_grab));
     }
 }
 
@@ -185,7 +181,7 @@ fn player_move(
                         KeyCode::A => velocity -= right,
                         KeyCode::D => velocity += right,
                         KeyCode::Space => velocity += Vec3::Y,
-                        KeyCode::LShift => velocity -= Vec3::Y,
+                        KeyCode::ShiftLeft => velocity -= Vec3::Y,
                         _ => (),
                     },
                 }

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -7,12 +7,9 @@ struct LoopAudioInstanceHandle(Handle<AudioInstance>);
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
-        .add_system(start_audio.on_startup())
-        .add_system(display_help_text.on_startup())
-        .add_system(print_status)
-        .add_system(process_keyboard_input)
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, (start_audio, display_help_text))
+        .add_systems(Update, (print_status, process_keyboard_input))
         .run();
 }
 
@@ -56,10 +53,8 @@ fn display_help_text(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                size: Size {
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
-                },
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
                 ..Default::default()

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -11,7 +11,7 @@ use bevy_kira_audio::prelude::*;
 /// Depending on your machine, the number of sounds you can play before audio issues appear may differ.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins((DefaultPlugins, AudioPlugin))
         // We need to increase the queue sizes of the audio backend.
         // The default is 128 per queue, which is way too low for playing as many sounds
         // as this example does.
@@ -19,10 +19,8 @@ fn main() {
             sound_capacity: 8192,
             command_capacity: 4096,
         })
-        .add_plugin(AudioPlugin)
-        .add_system(prepare.on_startup())
-        .add_system(check)
-        .add_system(play)
+        .add_systems(Startup, prepare)
+        .add_systems(Update, (check, play))
         .run()
 }
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -6,10 +6,10 @@ use crate::channel::AudioCommandQue;
 use crate::instance::AudioInstance;
 use crate::source::AudioSource;
 use crate::AudioSystemSet;
-use bevy::app::{App, CoreSet};
+use bevy::app::{App, PostUpdate, PreUpdate};
 use bevy::asset::{Handle, HandleId};
 use bevy::ecs::system::Resource;
-use bevy::prelude::{default, IntoSystemConfig};
+use bevy::prelude::{default, IntoSystemConfigs};
 use kira::sound::static_sound::{StaticSoundData, StaticSoundHandle};
 use kira::sound::{EndPosition, PlaybackPosition, Region};
 use kira::tween::Value;
@@ -423,10 +423,9 @@ pub trait AudioApp {
     ///
     /// fn main() {
     ///     App::new()
-    ///         .add_plugins(DefaultPlugins)
-    ///         .add_plugin(AudioPlugin)
+    ///         .add_plugins((DefaultPlugins, AudioPlugin))
     ///         .add_audio_channel::<Background>()
-    ///         .add_system(play.on_startup())
+    ///         .add_systems(Startup, play)
     ///         .run();
     /// }
     ///
@@ -442,15 +441,13 @@ pub trait AudioApp {
 
 impl AudioApp for App {
     fn add_audio_channel<T: Resource>(&mut self) -> &mut Self {
-        self.add_system(
-            play_audio_channel::<T>
-                .in_base_set(CoreSet::PostUpdate)
-                .in_set(AudioSystemSet::PlayTypedChannels),
+        self.add_systems(
+            PostUpdate,
+            play_audio_channel::<T>.in_set(AudioSystemSet::PlayTypedChannels),
         )
-        .add_system(
-            update_instance_states::<T>
-                .in_base_set(CoreSet::PreUpdate)
-                .after(AudioSystemSet::InstanceCleanup),
+        .add_systems(
+            PreUpdate,
+            update_instance_states::<T>.after(AudioSystemSet::InstanceCleanup),
         )
         .insert_resource(AudioChannel::<T>::default())
     }

--- a/src/audio_output.rs
+++ b/src/audio_output.rs
@@ -457,9 +457,7 @@ mod test {
     fn keeps_order_of_commands_to_retry() {
         // we only need this app to conveniently get a assets collection for `AudioSource`...
         let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_plugin(AssetPlugin::default())
-            .add_plugin(AudioPlugin);
+        app.add_plugins((MinimalPlugins, AssetPlugin::default(), AudioPlugin));
         let audio_source_assets = app.world.remove_resource::<Assets<AudioSource>>().unwrap();
         let mut audio_instance_assets = app
             .world
@@ -502,9 +500,7 @@ mod test {
     fn stop_command_removes_previous_play_commands() {
         // we only need this app to conveniently get a assets collection for `AudioSource`...
         let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_plugin(AssetPlugin::default())
-            .add_plugin(AudioPlugin);
+        app.add_plugins((MinimalPlugins, AssetPlugin::default(), AudioPlugin));
         let audio_source_assets = app.world.remove_resource::<Assets<AudioSource>>().unwrap();
         let mut audio_instance_assets = app
             .world

--- a/src/channel/typed.rs
+++ b/src/channel/typed.rs
@@ -15,7 +15,7 @@ use std::marker::PhantomData;
 
 /// Channel to play and control audio
 ///
-/// Add your own channels via [`add_audio_channel`](AudioApp::add_audio_channel).
+/// Add your own channels via [`add_audio_channel`](crate::audio::AudioApp::add_audio_channel).
 /// By default, there is only the [`AudioChannel<MainTrack>`](crate::Audio) channel.
 #[derive(Resource)]
 pub struct AudioChannel<T> {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,11 +1,12 @@
 use crate::{AudioTween, PlaybackState};
 use bevy::asset::{Assets, Handle};
+use bevy::reflect::{TypePath, TypeUuid};
 use kira::sound::static_sound::StaticSoundHandle;
 use kira::tween::Value;
 use kira::{CommandError, Volume};
 use thiserror::Error;
 
-#[derive(bevy::reflect::TypeUuid)]
+#[derive(TypeUuid, TypePath)]
 #[uuid = "77f84bee-42d6-4d83-9aac-929a9360f696"]
 /// Asset for direct audio control
 pub struct AudioInstance {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -11,11 +11,11 @@ pub mod settings_loader;
 #[cfg(feature = "wav")]
 pub mod wav_loader;
 
-use bevy::reflect::TypeUuid;
+use bevy::reflect::{TypePath, TypeUuid};
 use kira::sound::static_sound::StaticSoundData;
 
 /// A source of audio data
-#[derive(Clone, TypeUuid)]
+#[derive(Clone, TypeUuid, TypePath)]
 #[uuid = "6a9fc4ca-b5b5-94d6-613c-522e2d9fe86d"]
 pub struct AudioSource {
     /// The Kira sound making up this `AudioSource`

--- a/src/spacial.rs
+++ b/src/spacial.rs
@@ -18,8 +18,7 @@ pub struct AudioEmitter {
 /// Component for the audio receiver
 ///
 /// Most likely you will want to add this component to your player or you camera.
-/// The entity needs a [`Transform`] and [`GlobalTransform`]. The view direction of the [`GlobalTransform`]
-/// will
+/// The entity needs a [`Transform`](bevy::prelude::Transform) and [`GlobalTransform`]. The view direction of the [`GlobalTransform`].
 #[derive(Component)]
 pub struct AudioReceiver;
 


### PR DESCRIPTION
Hi,
This PR updates `bevy_kira_audio` to use Bevy v0.11.

I've checked the following (with & without various features enabled):
- [x] All examples compile and run
- [x] All tests compile and pass
- [x] No clippy warnings/suggestions
- [x] No cargo doc warnings
