### PR TITLE
Make asset loaders public in prelude

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,21 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::instance::{AudioCommandError, AudioInstance, AudioInstanceAssetsExt};
     #[doc(hidden)]
+    #[cfg(feature = "flac")]
+    pub use crate::source::flac_loader::*;
+    #[doc(hidden)]
+    #[cfg(feature = "mp3")]
+    pub use crate::source::mp3_loader::*;
+    #[doc(hidden)]
+    #[cfg(feature = "ogg")]
+    pub use crate::source::ogg_loader::*;
+    #[doc(hidden)]
+    #[cfg(feature = "settings_loader")]
+    pub use crate::source::settings_loader::*;
+    #[doc(hidden)]
+    #[cfg(feature = "wav")]
+    pub use crate::source::wav_loader::*;
+    #[doc(hidden)]
     pub use crate::source::AudioSource;
     #[doc(hidden)]
     pub use crate::spatial::{AudioEmitter, AudioReceiver, SpatialAudio};
@@ -80,7 +95,7 @@ pub mod prelude {
         dsp::Frame,
         sound::{
             static_sound::{StaticSoundData, StaticSoundSettings},
-            Sound, SoundData,
+            FromFileError, Sound, SoundData,
         },
         Volume,
     };

--- a/src/source/flac_loader.rs
+++ b/src/source/flac_loader.rs
@@ -21,6 +21,7 @@ pub enum FlacLoaderError {
     FileError(#[from] FromFileError),
 }
 
+/// Asset loader for FLAC files.
 #[derive(Default)]
 pub struct FlacLoader;
 

--- a/src/source/mp3_loader.rs
+++ b/src/source/mp3_loader.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 
 use crate::source::AudioSource;
 
+/// Asset loader for MP3 files.
 #[derive(Default)]
 pub struct Mp3Loader;
 

--- a/src/source/ogg_loader.rs
+++ b/src/source/ogg_loader.rs
@@ -21,6 +21,7 @@ pub enum OggLoaderError {
     FileError(#[from] FromFileError),
 }
 
+/// Asset loader for OGG files.
 #[derive(Default)]
 pub struct OggLoader;
 

--- a/src/source/settings_loader.rs
+++ b/src/source/settings_loader.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 
 use crate::AudioSource;
 
+/// Asset loader for sound settings files.
 #[derive(Default)]
 pub struct SettingsLoader;
 

--- a/src/source/wav_loader.rs
+++ b/src/source/wav_loader.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 
 use crate::source::AudioSource;
 
+/// Asset loader for WAV files.
 #[derive(Default)]
 pub struct WavLoader;
 


### PR DESCRIPTION
I'm trying to make some asset processing types (`AssetLoader`, `AssetTransformer`, `AssetSaver`) and I need to be able to use `WavLoader` and `FromFileError`, so I've added them to prelude.