### PR TITLE
Per Entity `SpatialRadius` for controlling spatial audio ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.21.0
+- add `SpatialRadius` to control spatial audio distance range per entity
+- rename `SpatialAudio` to `GlobalSpatialRadius` and rename it's field `max_distance` to `radius`
+
 ## v0.20.0 - 04.07.2024
 - Update to Bevy `0.14`
 - Asset loaders are now public

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -3,10 +3,18 @@ use bevy::prelude::*;
 use bevy::window::{CursorGrabMode, PrimaryWindow};
 use bevy_kira_audio::prelude::*;
 
+/// This example demonstrates the basic spatial audio support in `bevy_kira_audio`.
+/// It adds `SpatialAudioPlugin` then spawns entities with `SpatialAudioEmitter`
+/// and a receiver with the `SpatialAudioReceiver` component.
+
 fn main() {
     App::new()
-        .insert_resource(GlobalSpatialRadius { radius: 25. })
-        .add_plugins((DefaultPlugins, AudioPlugin, CameraPlugin))
+        .add_plugins((
+            DefaultPlugins,
+            AudioPlugin,
+            SpatialAudioPlugin,
+            CameraPlugin,
+        ))
         .add_systems(Startup, setup)
         .run();
 }
@@ -23,32 +31,33 @@ fn setup(
         .play(asset_server.load("sounds/cooking.ogg"))
         .looped()
         .handle();
-    commands
-        .spawn((
-            SceneRoot(asset_server.load("models/panStew.glb#Scene0")),
-            Transform::from_xyz(-5.0, 0., 0.),
-        ))
-        .insert(AudioEmitter {
+    commands.spawn((
+        SceneRoot(asset_server.load("models/panStew.glb#Scene0")),
+        Transform::from_xyz(-5.0, 0., 0.),
+        SpatialAudioEmitter {
             instances: vec![cooking],
-        })
-        .insert(SpatialRadius { radius: 10.0 });
+        },
+        // at a distance of more than 10, we will not hear this emitter anymore
+        SpatialRadius { radius: 10.0 },
+    ));
     // Emitter Nr. 2
     let elevator_music = audio
         .play(asset_server.load("sounds/loop.ogg"))
         .looped()
         .handle();
-    commands
-        .spawn((
-            SceneRoot(asset_server.load("models/boxOpen.glb#Scene0")),
-            Transform::from_xyz(10., 0., 0.),
-        ))
-        .insert(AudioEmitter {
+    commands.spawn((
+        SceneRoot(asset_server.load("models/boxOpen.glb#Scene0")),
+        Transform::from_xyz(10., 0., 0.),
+        SpatialAudioEmitter {
             instances: vec![elevator_music],
-        });
-    // Our camera will be the receiver
+        },
+    ));
+    // If an emitter has no SpatialRadius, the resource DefaultSpatialRadius is used instead.
+    // It defaults to a spatial radius of 25.
+    // Our camera will be the receiver.
     commands
         .spawn((Camera3d::default(), Transform::from_xyz(0.0, 0.5, 10.0)))
-        .insert(AudioReceiver)
+        .insert(SpatialAudioReceiver)
         .insert(FlyCam);
 
     // Other scene setup...

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -6,7 +6,7 @@ use bevy_kira_audio::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(SpatialAudio { max_distance: 25. })
+        .insert_resource(GlobalSpatialRadius { radius: 25. })
         .add_plugins((DefaultPlugins, AudioPlugin, CameraPlugin))
         .add_systems(Startup, setup)
         .run();
@@ -32,7 +32,8 @@ fn setup(
         })
         .insert(AudioEmitter {
             instances: vec![cooking],
-        });
+        })
+        .insert(SpatialRadius { radius: 10.0 });
     // Emitter Nr. 2
     let elevator_music = audio
         .play(asset_server.load("sounds/loop.ogg"))

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -6,7 +6,6 @@ use bevy_kira_audio::prelude::*;
 /// This example demonstrates the basic spatial audio support in `bevy_kira_audio`.
 /// It adds `SpatialAudioPlugin` then spawns entities with `SpatialAudioEmitter`
 /// and a receiver with the `SpatialAudioReceiver` component.
-
 fn main() {
     App::new()
         .add_plugins((

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,6 @@ use bevy::app::{PostUpdate, PreUpdate};
 use bevy::asset::AssetApp;
 pub use channel::AudioControl;
 pub use source::AudioSource;
-use spatial::{cleanup_stopped_spatial_instances, spatial_audio_enabled};
 
 /// Most commonly used types
 pub mod prelude {
@@ -113,7 +112,6 @@ use crate::source::ogg_loader::OggLoader;
 use crate::source::settings_loader::SettingsLoader;
 #[cfg(feature = "wav")]
 use crate::source::wav_loader::WavLoader;
-use crate::spatial::run_spatial_audio;
 use bevy::prelude::{App, IntoSystemConfigs, Plugin, Resource, SystemSet};
 pub use channel::dynamic::DynamicAudioChannel;
 pub use channel::dynamic::DynamicAudioChannels;
@@ -170,7 +168,8 @@ impl Plugin for AudioPlugin {
         #[cfg(feature = "settings_loader")]
         app.init_asset_loader::<SettingsLoader>();
 
-        app.init_resource::<DynamicAudioChannels>()
+        app.add_plugins(spatial::SpatialAudioPlugin)
+            .init_resource::<DynamicAudioChannels>()
             .add_systems(
                 PostUpdate,
                 play_dynamic_channels.in_set(AudioSystemSet::PlayDynamicChannels),
@@ -179,14 +178,7 @@ impl Plugin for AudioPlugin {
                 PreUpdate,
                 cleanup_stopped_instances.in_set(AudioSystemSet::InstanceCleanup),
             )
-            .add_audio_channel::<MainTrack>()
-            .add_systems(
-                PreUpdate,
-                cleanup_stopped_spatial_instances
-                    .in_set(AudioSystemSet::InstanceCleanup)
-                    .run_if(spatial_audio_enabled),
-            )
-            .add_systems(PostUpdate, run_spatial_audio.run_if(spatial_audio_enabled));
+            .add_audio_channel::<MainTrack>();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,10 @@ use bevy::app::{PostUpdate, PreUpdate};
 use bevy::asset::AssetApp;
 pub use channel::AudioControl;
 pub use source::AudioSource;
+pub use spatial::{
+    DefaultSpatialRadius, SpatialAudioEmitter, SpatialAudioPlugin, SpatialAudioReceiver,
+    SpatialRadius,
+};
 
 /// Most commonly used types
 pub mod prelude {
@@ -87,7 +91,10 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::source::AudioSource;
     #[doc(hidden)]
-    pub use crate::spatial::{AudioEmitter, AudioReceiver, GlobalSpatialRadius, SpatialRadius};
+    pub use crate::spatial::{
+        DefaultSpatialRadius, SpatialAudioEmitter, SpatialAudioPlugin, SpatialAudioReceiver,
+        SpatialRadius,
+    };
     #[doc(hidden)]
     pub use crate::{Audio, AudioPlugin, MainTrack};
     pub use kira::{
@@ -167,8 +174,7 @@ impl Plugin for AudioPlugin {
         #[cfg(feature = "settings_loader")]
         app.init_asset_loader::<SettingsLoader>();
 
-        app.add_plugins(spatial::SpatialAudioPlugin)
-            .init_resource::<DynamicAudioChannels>()
+        app.init_resource::<DynamicAudioChannels>()
             .add_systems(
                 PostUpdate,
                 play_dynamic_channels.in_set(AudioSystemSet::PlayDynamicChannels),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::source::AudioSource;
     #[doc(hidden)]
-    pub use crate::spatial::{AudioEmitter, AudioReceiver, SpatialAudio};
+    pub use crate::spatial::{AudioEmitter, AudioReceiver, GlobalSpatialRadius, SpatialRadius};
     #[doc(hidden)]
     pub use crate::{Audio, AudioPlugin, MainTrack};
     pub use kira::{
@@ -113,7 +113,7 @@ use crate::source::ogg_loader::OggLoader;
 use crate::source::settings_loader::SettingsLoader;
 #[cfg(feature = "wav")]
 use crate::source::wav_loader::WavLoader;
-use crate::spatial::{run_spatial_audio, SpatialAudio};
+use crate::spatial::{run_spatial_audio, GlobalSpatialRadius};
 use bevy::prelude::{resource_exists, App, IntoSystemConfigs, Plugin, Resource, SystemSet};
 pub use channel::dynamic::DynamicAudioChannel;
 pub use channel::dynamic::DynamicAudioChannels;
@@ -184,11 +184,11 @@ impl Plugin for AudioPlugin {
                 PreUpdate,
                 cleanup_stopped_spatial_instances
                     .in_set(AudioSystemSet::InstanceCleanup)
-                    .run_if(resource_exists::<SpatialAudio>),
+                    .run_if(resource_exists::<GlobalSpatialRadius>),
             )
             .add_systems(
                 PostUpdate,
-                run_spatial_audio.run_if(resource_exists::<SpatialAudio>),
+                run_spatial_audio.run_if(resource_exists::<GlobalSpatialRadius>),
             );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ use bevy::app::{PostUpdate, PreUpdate};
 use bevy::asset::AssetApp;
 pub use channel::AudioControl;
 pub use source::AudioSource;
-use spatial::cleanup_stopped_spatial_instances;
+use spatial::{cleanup_stopped_spatial_instances, spatial_audio_enabled};
 
 /// Most commonly used types
 pub mod prelude {
@@ -113,8 +113,8 @@ use crate::source::ogg_loader::OggLoader;
 use crate::source::settings_loader::SettingsLoader;
 #[cfg(feature = "wav")]
 use crate::source::wav_loader::WavLoader;
-use crate::spatial::{run_spatial_audio, GlobalSpatialRadius};
-use bevy::prelude::{resource_exists, App, IntoSystemConfigs, Plugin, Resource, SystemSet};
+use crate::spatial::run_spatial_audio;
+use bevy::prelude::{App, IntoSystemConfigs, Plugin, Resource, SystemSet};
 pub use channel::dynamic::DynamicAudioChannel;
 pub use channel::dynamic::DynamicAudioChannels;
 pub use channel::typed::AudioChannel;
@@ -184,12 +184,9 @@ impl Plugin for AudioPlugin {
                 PreUpdate,
                 cleanup_stopped_spatial_instances
                     .in_set(AudioSystemSet::InstanceCleanup)
-                    .run_if(resource_exists::<GlobalSpatialRadius>),
+                    .run_if(spatial_audio_enabled),
             )
-            .add_systems(
-                PostUpdate,
-                run_spatial_audio.run_if(resource_exists::<GlobalSpatialRadius>),
-            );
+            .add_systems(PostUpdate, run_spatial_audio.run_if(spatial_audio_enabled));
     }
 }
 

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -82,3 +82,10 @@ pub(crate) fn cleanup_stopped_spatial_instances(
         });
     });
 }
+
+pub(crate) fn spatial_audio_enabled(
+    global: Option<Res<GlobalSpatialRadius>>,
+    local: Query<(), With<SpatialRadius>>,
+) -> bool {
+    global.is_some() || !local.is_empty()
+}

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -74,15 +74,11 @@ pub(crate) fn cleanup_stopped_spatial_instances(
     mut emitters: Query<&mut AudioEmitter>,
     instances: ResMut<Assets<AudioInstance>>,
 ) {
-    for mut emitter in emitters.iter_mut() {
-        let handles = &mut emitter.instances;
-
-        handles.retain(|handle| {
-            if let Some(instance) = instances.get(handle) {
-                instance.handle.state() != kira::sound::PlaybackState::Stopped
-            } else {
-                true
-            }
+    emitters.iter_mut().for_each(|mut emitter| {
+        emitter.instances.retain(|handle| {
+            instances.get(handle).map_or(true, |instance| {
+                !matches!(instance.handle.state(), kira::sound::PlaybackState::Stopped)
+            })
         });
-    }
+    });
 }


### PR DESCRIPTION
It was one of the first things that naturally seemed to be missing. This basically tackles https://github.com/NiklasEi/bevy_kira_audio/issues/121.

I updated the example, so now the cooking pot is only hearable if you're really closeby while you can still listen to the radio from a greater distance.

There were a few other small changes I made when working on this. I just couldn't help but make the code here and there more idiomic.