### PR TITLE
Update Kira to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,12 @@ wav = ["kira/wav"]
 settings_loader = ["dep:ron", "dep:serde", "kira/serde"]
 
 [dependencies]
-bevy = { version = "0.14.0", default-features = false, features = ["bevy_asset"] }
+bevy = { version = "0.14.0", default-features = false, features = [
+    "bevy_asset",
+] }
 anyhow = "1.0"
 uuid = { version = "1", features = ["fast-rng"] }
-kira = { version = "0.8", default-features = false, features = ["cpal"] }
+kira = { version = "0.9", default-features = false, features = ["cpal"] }
 ron = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 parking_lot = "0.12"
@@ -49,7 +51,7 @@ features = [
     "tonemapping_luts",
     "ktx2",
     "zstd",
-    "multi_threaded"
+    "multi_threaded",
 ]
 
 [[example]]

--- a/src/backend_settings.rs
+++ b/src/backend_settings.rs
@@ -17,7 +17,7 @@ pub struct AudioSettings {
     /// Note that configuring a channel will cause one command per sound in the channel!
     pub command_capacity: usize,
     /// The maximum number of sounds that can be playing at a time.
-    pub sound_capacity: usize,
+    pub sound_capacity: u16,
 }
 
 impl Default for AudioSettings {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2,8 +2,7 @@ use crate::{AudioTween, PlaybackState};
 use bevy::asset::{Asset, Assets, Handle};
 use kira::sound::static_sound::StaticSoundHandle;
 use kira::tween::Value;
-use kira::{CommandError, Volume};
-use thiserror::Error;
+use kira::Volume;
 
 #[derive(Asset, bevy::reflect::TypePath)]
 /// Asset for direct audio control
@@ -11,50 +10,20 @@ pub struct AudioInstance {
     pub(crate) handle: StaticSoundHandle,
 }
 
-/// Errors that can occur when directly controlling audio
-#[derive(Error, Debug)]
-pub enum AudioCommandError {
-    /// The audio command que of the audio manager is full
-    #[error("the audio thread could not handle the command, because its command que is full")]
-    CommandQueueFull,
-
-    /// Something went wrong when handling the command in the audio thread
-    #[error("an error occurred while handling the command in the audio thread")]
-    AudioThreadError,
-}
-
-impl From<CommandError> for AudioCommandError {
-    fn from(kira_error: CommandError) -> Self {
-        match kira_error {
-            CommandError::CommandQueueFull => AudioCommandError::CommandQueueFull,
-            _ => AudioCommandError::AudioThreadError,
-        }
-    }
-}
-
 impl AudioInstance {
     /// Pause the audio instance with the given easing
-    pub fn pause(&mut self, tween: AudioTween) -> Option<AudioCommandError> {
-        self.handle
-            .pause(tween.into())
-            .err()
-            .map(|kira_error| kira_error.into())
+    pub fn pause(&mut self, tween: AudioTween) {
+        self.handle.pause(tween.into());
     }
 
     /// Resume the audio instance with the given easing
-    pub fn resume(&mut self, tween: AudioTween) -> Option<AudioCommandError> {
-        self.handle
-            .resume(tween.into())
-            .err()
-            .map(|kira_error| kira_error.into())
+    pub fn resume(&mut self, tween: AudioTween) {
+        self.handle.resume(tween.into());
     }
 
     /// Stop the audio instance with the given easing
-    pub fn stop(&mut self, tween: AudioTween) -> Option<AudioCommandError> {
-        self.handle
-            .stop(tween.into())
-            .err()
-            .map(|kira_error| kira_error.into())
+    pub fn stop(&mut self, tween: AudioTween) {
+        self.handle.stop(tween.into());
     }
 
     /// Get the state of the audio instance
@@ -65,30 +34,16 @@ impl AudioInstance {
     /// Set the volume of the audio instance
     ///
     /// Default is `1.0`
-    pub fn set_volume(
-        &mut self,
-        volume: impl Into<Value<Volume>>,
-        tween: AudioTween,
-    ) -> Option<AudioCommandError> {
-        self.handle
-            .set_volume(volume, tween.into())
-            .err()
-            .map(|kira_error| kira_error.into())
+    pub fn set_volume(&mut self, volume: impl Into<Value<Volume>>, tween: AudioTween) {
+        self.handle.set_volume(volume, tween.into());
     }
 
     /// Sets the playback rate of the sound.
     ///
     /// Changing the playback rate will change both the speed
     /// and pitch of the sound.
-    pub fn set_playback_rate(
-        &mut self,
-        playback_rate: f64,
-        tween: AudioTween,
-    ) -> Option<AudioCommandError> {
-        self.handle
-            .set_playback_rate(playback_rate, tween.into())
-            .err()
-            .map(|kira_error| kira_error.into())
+    pub fn set_playback_rate(&mut self, playback_rate: f64, tween: AudioTween) {
+        self.handle.set_playback_rate(playback_rate, tween.into());
     }
 
     /// Sets the panning of the sound
@@ -96,27 +51,18 @@ impl AudioInstance {
     /// `0.0` is hard left,
     /// `0.5` is center (default)
     /// `1.0` is hard right.
-    pub fn set_panning(&mut self, panning: f64, tween: AudioTween) -> Option<AudioCommandError> {
-        self.handle
-            .set_panning(panning, tween.into())
-            .err()
-            .map(|kira_error| kira_error.into())
+    pub fn set_panning(&mut self, panning: f64, tween: AudioTween) {
+        self.handle.set_panning(panning, tween.into());
     }
 
     /// Sets the playback position to the specified time in seconds.
-    pub fn seek_to(&mut self, position: f64) -> Option<AudioCommandError> {
-        self.handle
-            .seek_to(position)
-            .err()
-            .map(|kira_error| kira_error.into())
+    pub fn seek_to(&mut self, position: f64) {
+        self.handle.seek_to(position);
     }
 
     /// Moves the playback position by the specified amount of time in seconds.
-    pub fn seek_by(&mut self, amount: f64) -> Option<AudioCommandError> {
-        self.handle
-            .seek_by(amount)
-            .err()
-            .map(|kira_error| kira_error.into())
+    pub fn seek_by(&mut self, amount: f64) {
+        self.handle.seek_by(amount);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::channel::AudioControl;
     #[doc(hidden)]
-    pub use crate::instance::{AudioCommandError, AudioInstance, AudioInstanceAssetsExt};
+    pub use crate::instance::{AudioInstance, AudioInstanceAssetsExt};
     #[doc(hidden)]
     #[cfg(feature = "flac")]
     pub use crate::source::flac_loader::*;
@@ -92,12 +92,11 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{Audio, AudioPlugin, MainTrack};
     pub use kira::{
-        dsp::Frame,
         sound::{
             static_sound::{StaticSoundData, StaticSoundSettings},
             FromFileError, Sound, SoundData,
         },
-        Volume,
+        Frame, Volume,
     };
 }
 

--- a/src/source/flac_loader.rs
+++ b/src/source/flac_loader.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use bevy::asset::io::Reader;
 use bevy::asset::{AssetLoader, AsyncReadExt, LoadContext};
-use kira::sound::static_sound::{StaticSoundData, StaticSoundSettings};
+use kira::sound::static_sound::StaticSoundData;
 use kira::sound::FromFileError;
 use std::io::Cursor;
 use thiserror::Error;
@@ -37,8 +37,7 @@ impl AssetLoader for FlacLoader {
     ) -> Result<Self::Asset, Self::Error> {
         let mut sound_bytes = vec![];
         reader.read_to_end(&mut sound_bytes).await?;
-        let sound =
-            StaticSoundData::from_cursor(Cursor::new(sound_bytes), StaticSoundSettings::default())?;
+        let sound = StaticSoundData::from_cursor(Cursor::new(sound_bytes))?;
         Ok(AudioSource { sound })
     }
 

--- a/src/source/mp3_loader.rs
+++ b/src/source/mp3_loader.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use bevy::asset::io::Reader;
 use bevy::asset::{AssetLoader, AsyncReadExt, LoadContext};
-use kira::sound::static_sound::{StaticSoundData, StaticSoundSettings};
+use kira::sound::static_sound::StaticSoundData;
 use kira::sound::FromFileError;
 use std::io::Cursor;
 use thiserror::Error;
@@ -37,8 +37,7 @@ impl AssetLoader for Mp3Loader {
     ) -> Result<Self::Asset, Self::Error> {
         let mut sound_bytes = vec![];
         reader.read_to_end(&mut sound_bytes).await?;
-        let sound =
-            StaticSoundData::from_cursor(Cursor::new(sound_bytes), StaticSoundSettings::default())?;
+        let sound = StaticSoundData::from_cursor(Cursor::new(sound_bytes))?;
         Ok(AudioSource { sound })
     }
 

--- a/src/source/ogg_loader.rs
+++ b/src/source/ogg_loader.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use bevy::asset::io::Reader;
 use bevy::asset::{AssetLoader, AsyncReadExt, LoadContext};
-use kira::sound::static_sound::{StaticSoundData, StaticSoundSettings};
+use kira::sound::static_sound::StaticSoundData;
 use kira::sound::FromFileError;
 use std::io::Cursor;
 use thiserror::Error;
@@ -37,8 +37,7 @@ impl AssetLoader for OggLoader {
     ) -> Result<Self::Asset, Self::Error> {
         let mut sound_bytes = vec![];
         reader.read_to_end(&mut sound_bytes).await?;
-        let sound =
-            StaticSoundData::from_cursor(Cursor::new(sound_bytes), StaticSoundSettings::default())?;
+        let sound = StaticSoundData::from_cursor(Cursor::new(sound_bytes))?;
         Ok(AudioSource { sound })
     }
 

--- a/src/source/wav_loader.rs
+++ b/src/source/wav_loader.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use bevy::asset::io::Reader;
 use bevy::asset::{AssetLoader, AsyncReadExt, LoadContext};
-use kira::sound::static_sound::{StaticSoundData, StaticSoundSettings};
+use kira::sound::static_sound::StaticSoundData;
 use kira::sound::FromFileError;
 use std::io::Cursor;
 use thiserror::Error;
@@ -37,8 +37,7 @@ impl AssetLoader for WavLoader {
     ) -> Result<Self::Asset, Self::Error> {
         let mut sound_bytes = vec![];
         reader.read_to_end(&mut sound_bytes).await?;
-        let sound =
-            StaticSoundData::from_cursor(Cursor::new(sound_bytes), StaticSoundSettings::default())?;
+        let sound = StaticSoundData::from_cursor(Cursor::new(sound_bytes))?;
         Ok(AudioSource { sound })
     }
     fn extensions(&self) -> &[&str] {


### PR DESCRIPTION
Updated Kira to 0.9.

In the latest, they made it audio commands do not fail, so the CommandError handling could be removed.

Also, the playback_region was changed to a "slice" on the StaticSoundData.