### PR TITLE
Derives Default for SpatialAudioReceiver

### DIFF
--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -50,7 +50,7 @@ pub struct SpatialAudioEmitter {
 ///
 /// Most likely you will want to add this component to your player or you camera.
 /// There can only ever be one entity with this component at a given time!
-#[derive(Component)]
+#[derive(Component, Default)]
 #[require(Transform)]
 pub struct SpatialAudioReceiver;
 


### PR DESCRIPTION
I noticed that I was not able to use `SpatialAudioReceiver` as a required component, so I've added the `Default` derive to it to enable this.