### PR TITLE
Add support for effects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,11 @@ path = "examples/multiple_effects_channel.rs"
 required-features = ["ogg"]
 
 [[example]]
+name = "effect_tail"
+path = "examples/effect_tail.rs"
+required-features = ["ogg"]
+
+[[example]]
 name = "peak_meter"
 path = "examples/peak_meter.rs"
 required-features = ["ogg"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,41 @@ path = "examples/channel_control.rs"
 required-features = ["ogg"]
 
 [[example]]
+name = "reverb"
+path = "examples/reverb.rs"
+required-features = ["ogg"]
+
+[[example]]
+name = "filter"
+path = "examples/filter.rs"
+required-features = ["ogg"]
+
+[[example]]
+name = "filter_basic"
+path = "examples/filter_basic.rs"
+required-features = ["ogg"]
+
+[[example]]
+name = "reverb_channel"
+path = "examples/reverb_channel.rs"
+required-features = ["ogg"]
+
+[[example]]
+name = "multiple_effects"
+path = "examples/multiple_effects.rs"
+required-features = ["ogg"]
+
+[[example]]
+name = "multiple_effects_channel"
+path = "examples/multiple_effects_channel.rs"
+required-features = ["ogg"]
+
+[[example]]
+name = "peak_meter"
+path = "examples/peak_meter.rs"
+required-features = ["ogg"]
+
+[[example]]
 name = "spatial"
 path = "examples/spatial.rs"
 required-features = ["ogg"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,11 @@ path = "examples/multiple_effects_channel.rs"
 required-features = ["ogg"]
 
 [[example]]
+name = "stacked_effects"
+path = "examples/stacked_effects.rs"
+required-features = ["ogg"]
+
+[[example]]
 name = "effect_tail"
 path = "examples/effect_tail.rs"
 required-features = ["ogg"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ fn play_audio(asset_server: Res<AssetServer>, audio: Res<Audio>) {
         .with_playback_rate(1.5)
         // Play at lower volume (-10dB)
         .with_volume(-10.)
+        // Apply a low-pass filter effect
+        .with_effect(FilterBuilder::new().cutoff(4000.0))
         // play the track reversed
         .reverse();
 }
@@ -78,6 +80,14 @@ More settings are available. See the [`settings_loader` example](examples/settin
 ### Controlling sounds
 
 You can either control a whole audio channel and all instances playing in it ([`channel_control` example](examples/channel_control.rs)), or a single audio instance ([`instance_control` example](examples/instance_control.rs)). Both ways offer audio transitions with Tweens supporting multiple easings.
+
+### Effects
+
+Effects modify the audio signal of a single sound or of a whole channel. Adding an effect returns a handle to control it while it plays.
+
+Add them to a single sound instance ([`filter` example](examples/filter.rs)), or to an `AudioTrack` that applies them to every sound on a channel ([`reverb_channel` example](examples/reverb_channel.rs)). Multiple effects can be chained ([`multiple_effects` example](examples/multiple_effects.rs)).
+
+The built-in effects are filter, reverb, delay, distortion, compressor, EQ filter, volume control and panning control. You can also write your own by implementing `Effect` and `AudioEffect` ([`peak_meter` example](examples/peak_meter.rs)).
 
 ### Spatial audio
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Effects modify the audio signal of a single sound or of a whole channel. Adding 
 
 Add them to a single sound instance ([`filter` example](examples/filter.rs)), or to an `AudioTrack` that applies them to every sound on a channel ([`reverb_channel` example](examples/reverb_channel.rs)). Multiple effects can be chained ([`multiple_effects` example](examples/multiple_effects.rs)).
 
+Effects on a single sound keep running for a short while after that sound stops, so reverb and delay tails are not cut off. Use `with_effect_tail` to give a long reverb more time, or to reclaim the track sooner ([`effect_tail` example](examples/effect_tail.rs)).
+
 The built-in effects are filter, reverb, delay, distortion, compressor, EQ filter, volume control and panning control. You can also write your own by implementing `Effect` and `AudioEffect` ([`peak_meter` example](examples/peak_meter.rs)).
 
 ### Spatial audio

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Effects modify the audio signal of a single sound or of a whole channel. Adding 
 
 Add them to a single sound instance ([`filter` example](examples/filter.rs)), or to an `AudioTrack` that applies them to every sound on a channel ([`reverb_channel` example](examples/reverb_channel.rs)). Multiple effects can be chained ([`multiple_effects` example](examples/multiple_effects.rs)).
 
+Both kinds stack: a sound with per-instance effects played on a channel with its own track is processed by the per-instance effects first, then by the channel effects ([`stacked_effects` example](examples/stacked_effects.rs)).
+
 Effects on a single sound keep running for a short while after that sound stops, so reverb and delay tails are not cut off. Use `with_effect_tail` to give a long reverb more time, or to reclaim the track sooner ([`effect_tail` example](examples/effect_tail.rs)).
 
 The built-in effects are filter, reverb, delay, distortion, compressor, EQ filter, volume control and panning control. You can also write your own by implementing `Effect` and `AudioEffect` ([`peak_meter` example](examples/peak_meter.rs)).

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,7 @@ These examples are simple Bevy Apps illustrating the capabilities of `bevy_kira_
 | [`settings.rs`](/examples/settings.rs)                   | Demonstrate settings supported when playing a sound                  |
 | [`settings_loader.rs`](/examples/settings_loader.rs)     | Loading a sound with applied settings                                |
 | [`spatial.rs`](/examples/spatial.rs)                     | Demonstration of the limited support for spatial audio               |
+| [`stacked_effects.rs`](/examples/stacked_effects.rs)     | A per-sound effect and a channel effect applied to the same sound    |
 | [`status.rs`](/examples/status.rs)                       | Continuously get the playback state of a sound                       |
 | [`stress_test.rs`](/examples/stress_test.rs)             | Example app playing a high number of sounds every frame              |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,8 +8,15 @@ These examples are simple Bevy Apps illustrating the capabilities of `bevy_kira_
 | [`channel_control.rs`](/examples/channel_control.rs)     | Demonstrate controlling an audio channel                             |
 | [`custom_channel.rs`](/examples/custom_channel.rs)       | How to add and use a custom audio channel                            |
 | [`dynamic_channels.rs`](/examples/dynamic_channels.rs)   | Usage of dynamic audio channels                                      |
+| [`filter.rs`](/examples/filter.rs)                       | Per-instance low-pass filter with runtime cutoff toggling            |
+| [`filter_basic.rs`](/examples/filter_basic.rs)           | Simple low-pass filter using `with_effect` (no runtime control)      |
 | [`instance_control.rs`](/examples/instance_control.rs)   | Demonstrate controlling a single audio instance                      |
 | [`multiple_channels.rs`](/examples/multiple_channels.rs) | GUI application with full control over tree different audio channels |
+| [`multiple_effects.rs`](/examples/multiple_effects.rs)   | Three effects on one sound instance, cycled at runtime               |
+| [`multiple_effects_channel.rs`](/examples/multiple_effects_channel.rs) | Interactive demo toggling three channel-level effects   |
+| [`peak_meter.rs`](/examples/peak_meter.rs)               | A custom effect measuring loudness to drive a UI meter               |
+| [`reverb.rs`](/examples/reverb.rs)                       | Per-instance reverb with runtime on/off toggling                     |
+| [`reverb_channel.rs`](/examples/reverb_channel.rs)       | Channel-level reverb applied to multiple sounds                      |
 | [`settings.rs`](/examples/settings.rs)                   | Demonstrate settings supported when playing a sound                  |
 | [`settings_loader.rs`](/examples/settings_loader.rs)     | Loading a sound with applied settings                                |
 | [`spatial.rs`](/examples/spatial.rs)                     | Demonstration of the limited support for spatial audio               |

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ These examples are simple Bevy Apps illustrating the capabilities of `bevy_kira_
 | [`channel_control.rs`](/examples/channel_control.rs)     | Demonstrate controlling an audio channel                             |
 | [`custom_channel.rs`](/examples/custom_channel.rs)       | How to add and use a custom audio channel                            |
 | [`dynamic_channels.rs`](/examples/dynamic_channels.rs)   | Usage of dynamic audio channels                                      |
+| [`effect_tail.rs`](/examples/effect_tail.rs)             | How long effects keep ringing after a sound stops                    |
 | [`filter.rs`](/examples/filter.rs)                       | Per-instance low-pass filter with runtime cutoff toggling            |
 | [`filter_basic.rs`](/examples/filter_basic.rs)           | Simple low-pass filter using `with_effect` (no runtime control)      |
 | [`instance_control.rs`](/examples/instance_control.rs)   | Demonstrate controlling a single audio instance                      |

--- a/examples/channel_control.rs
+++ b/examples/channel_control.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
-use kira::Easing;
 use std::time::Duration;
 
 // This example demonstrates how to control an audio channel
@@ -19,11 +18,11 @@ fn channel_control(input: Res<ButtonInput<MouseButton>>, audio: Res<Audio>) {
     if input.just_pressed(MouseButton::Left) {
         audio
             .pause()
-            .fade_out(AudioTween::new(Duration::from_secs(2), Easing::Linear));
+            .fade_out(AudioTween::new(Duration::from_secs(2), AudioEasing::Linear));
     } else if input.just_pressed(MouseButton::Right) {
         audio
             .resume()
-            .fade_in(AudioTween::new(Duration::from_secs(2), Easing::Linear));
+            .fade_in(AudioTween::new(Duration::from_secs(2), AudioEasing::Linear));
     }
 }
 

--- a/examples/effect_tail.rs
+++ b/examples/effect_tail.rs
@@ -1,0 +1,147 @@
+use bevy::prelude::*;
+use bevy_kira_audio::prelude::*;
+use std::time::Duration;
+
+/// Reverb and delay keep sounding after the sound feeding them has stopped. A sound with
+/// per-instance effects plays on a track of its own, and once that track goes away so does
+/// everything still ringing on it, so `with_effect_tail` decides how long it sticks around.
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .init_resource::<Ringing>()
+        .add_systems(Startup, setup)
+        .add_systems(Update, (play, update_status).chain())
+        .run();
+}
+
+const TAILS: [(KeyCode, Duration, &str); 3] = [
+    (KeyCode::Digit1, Duration::ZERO, "[1] no tail"),
+    (KeyCode::Digit2, Duration::from_millis(500), "[2] 500 ms"),
+    (KeyCode::Digit3, Duration::from_secs(2), "[3] 2 s"),
+];
+
+const COLOR_ALIVE: Color = Color::linear_rgb(0.3, 0.85, 0.4);
+const COLOR_GONE: Color = Color::linear_rgb(0.45, 0.45, 0.45);
+
+#[derive(Resource)]
+struct Plop(Handle<AudioSource>);
+
+/// The plop that was played last, and how much of its tail is left.
+#[derive(Resource, Default)]
+struct Ringing {
+    instance: Option<Handle<AudioInstance>>,
+    label: &'static str,
+    tail: Duration,
+    /// Counts down in real time once the plop itself has stopped. `None` while it is still playing.
+    left: Option<Duration>,
+}
+
+#[derive(Component)]
+struct StatusText;
+
+fn play(
+    keys: Res<ButtonInput<KeyCode>>,
+    audio: Res<Audio>,
+    plop: Res<Plop>,
+    mut ringing: ResMut<Ringing>,
+) {
+    for (key, tail, label) in TAILS {
+        if !keys.just_pressed(key) {
+            continue;
+        }
+
+        let mut cmd = audio.play(plop.0.clone());
+        cmd.with_effect(
+            ReverbBuilder::new()
+                .feedback(0.85)
+                .damping(0.2)
+                .mix(0.85_f32),
+        )
+        .with_effect_tail(tail);
+
+        *ringing = Ringing {
+            instance: Some(cmd.handle()),
+            label,
+            tail,
+            left: None,
+        };
+    }
+}
+
+fn update_status(
+    time: Res<Time<Real>>,
+    audio: Res<Audio>,
+    mut ringing: ResMut<Ringing>,
+    mut status: Single<(&mut Text, &mut TextColor), With<StatusText>>,
+) {
+    let Some(instance) = ringing.instance.clone() else {
+        return;
+    };
+
+    // The tail is counted from the moment the sound stops, not from the key press.
+    match ringing.left {
+        Some(left) => ringing.left = Some(left.saturating_sub(time.delta())),
+        None if audio.state(&instance) == PlaybackState::Stopped => {
+            ringing.left = Some(ringing.tail)
+        }
+        None => {}
+    }
+
+    let (state, alive) = match ringing.left {
+        None => ("plop playing".to_owned(), true),
+        Some(left) if left.is_zero() => ("track gone".to_owned(), false),
+        Some(left) => (format!("track alive {:.2}s more", left.as_secs_f32()), true),
+    };
+
+    let (text, color) = &mut *status;
+    **text = Text::new(format!("{}  -  {}", ringing.label, state));
+    color.0 = if alive { COLOR_ALIVE } else { COLOR_GONE };
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2d);
+    commands.insert_resource(Plop(asset_server.load("sounds/plop.ogg")));
+
+    let font = asset_server.load("fonts/monogram.ttf");
+    let normal = TextFont {
+        font: font.clone().into(),
+        font_size: 26.0.into(),
+        ..default()
+    };
+
+    commands
+        .spawn(Node {
+            flex_direction: FlexDirection::Column,
+            padding: UiRect::all(Val::Px(40.0)),
+            row_gap: Val::Px(24.0),
+            ..default()
+        })
+        .with_children(|parent| {
+            parent.spawn((
+                Text::new("Effect tails"),
+                TextFont {
+                    font: font.into(),
+                    font_size: 36.0.into(),
+                    ..default()
+                },
+                TextColor(Color::WHITE),
+            ));
+            parent.spawn((
+                Text::new(
+                    "The same plop through the same reverb\n\
+                     Only the time its track is kept alive differs.\n\n\
+                     [1] no tail\n\
+                     [2] 500 ms\n\
+                     [3] 2 s (the default, outlasts the reverb)",
+                ),
+                normal.clone(),
+                TextColor(Color::linear_rgb(0.7, 0.7, 0.7)),
+            ));
+            parent.spawn((
+                Text::new("press [1], [2] or [3]"),
+                normal,
+                TextColor(COLOR_GONE),
+                StatusText,
+            ));
+        });
+}

--- a/examples/filter.rs
+++ b/examples/filter.rs
@@ -1,0 +1,55 @@
+use bevy::prelude::*;
+use bevy_kira_audio::prelude::*;
+use std::time::Duration;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, play)
+        .add_systems(Update, toggle_filter)
+        .run();
+}
+
+fn play(audio: Res<Audio>, asset_server: Res<AssetServer>, mut commands: Commands) {
+    let mut cmd = audio.play(asset_server.load("sounds/loop.ogg"));
+    let filter = cmd.add_effect(
+        FilterBuilder::new()
+            .mode(FilterMode::LowPass)
+            .cutoff(20000.0) // start fully open
+            .mix(1.0_f32),
+    );
+    cmd.looped();
+
+    commands.insert_resource(FilterState {
+        handle: filter,
+        muffled: false,
+        timer: Timer::new(Duration::from_secs(3), TimerMode::Repeating),
+    });
+}
+
+fn toggle_filter(time: Res<Time>, mut state: ResMut<FilterState>) {
+    state.timer.tick(time.delta());
+    if !state.timer.just_finished() {
+        return;
+    }
+
+    state.muffled = !state.muffled;
+    let transition = AudioTween::linear(Duration::from_millis(150));
+
+    if state.muffled {
+        // Strong low-pass: only bass frequencies come through
+        state.handle.set_cutoff(300.0, transition);
+        info!("Filter ON (muffled)");
+    } else {
+        // Wide open: full spectrum
+        state.handle.set_cutoff(20000.0, transition);
+        info!("Filter OFF (clear)");
+    }
+}
+
+#[derive(Resource)]
+struct FilterState {
+    handle: FilterHandle,
+    muffled: bool,
+    timer: Timer,
+}

--- a/examples/filter_basic.rs
+++ b/examples/filter_basic.rs
@@ -1,0 +1,16 @@
+use bevy::prelude::*;
+use bevy_kira_audio::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, play)
+        .run();
+}
+
+fn play(audio: Res<Audio>, asset_server: Res<AssetServer>) {
+    audio
+        .play(asset_server.load("sounds/loop.ogg"))
+        .with_effect(FilterBuilder::new().mode(FilterMode::LowPass).cutoff(300.0))
+        .looped();
+}

--- a/examples/multiple_effects.rs
+++ b/examples/multiple_effects.rs
@@ -1,0 +1,88 @@
+use bevy::prelude::*;
+use bevy_kira_audio::prelude::*;
+use std::time::Duration;
+
+/// Demonstrates applying three effects to a single audio instance,
+/// then toggling them on and off at runtime.
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, play)
+        .add_systems(Update, cycle_effects)
+        .run();
+}
+
+fn play(audio: Res<Audio>, asset_server: Res<AssetServer>, mut commands: Commands) {
+    let mut cmd = audio.play(asset_server.load("sounds/loop.ogg"));
+
+    // Effect 1: low-pass filter (starts wide open)
+    let filter = cmd.add_effect(
+        FilterBuilder::new()
+            .mode(FilterMode::LowPass)
+            .cutoff(20000.0)
+            .mix(1.0_f32),
+    );
+
+    // Effect 2: delay (starts silent)
+    cmd.with_effect(
+        DelayBuilder::new()
+            .delay_time(Duration::from_millis(350))
+            .feedback(-8.0_f32)
+            .mix(0.0_f32),
+    );
+
+    // Effect 3: reverb (starts dry)
+    let reverb = cmd.add_effect(ReverbBuilder::new().feedback(0.8).damping(0.3).mix(0.0_f32));
+
+    cmd.looped();
+
+    commands.insert_resource(EffectsState {
+        filter,
+        reverb,
+        step: 0,
+        timer: Timer::new(Duration::from_secs(3), TimerMode::Repeating),
+    });
+}
+
+fn cycle_effects(time: Res<Time>, mut state: ResMut<EffectsState>) {
+    state.timer.tick(time.delta());
+    if !state.timer.just_finished() {
+        return;
+    }
+
+    let transition = AudioTween::linear(Duration::from_millis(200));
+
+    // Cycle through: dry -> filter -> reverb -> filter+reverb -> dry
+    state.step = (state.step + 1) % 4;
+    match state.step {
+        0 => {
+            state.filter.set_cutoff(20000.0, transition);
+            state.reverb.set_mix(0.0_f32, transition);
+            info!("All effects OFF (dry)");
+        }
+        1 => {
+            state.filter.set_cutoff(400.0, transition);
+            state.reverb.set_mix(0.0_f32, transition);
+            info!("Filter ON (muffled)");
+        }
+        2 => {
+            state.filter.set_cutoff(20000.0, transition);
+            state.reverb.set_mix(0.6_f32, transition);
+            info!("Reverb ON");
+        }
+        3 => {
+            state.filter.set_cutoff(400.0, transition);
+            state.reverb.set_mix(0.6_f32, transition);
+            info!("Filter + Reverb ON");
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[derive(Resource)]
+struct EffectsState {
+    filter: FilterHandle,
+    reverb: ReverbHandle,
+    step: usize,
+    timer: Timer,
+}

--- a/examples/multiple_effects_channel.rs
+++ b/examples/multiple_effects_channel.rs
@@ -1,0 +1,293 @@
+use bevy::ecs::relationship::RelatedSpawnerCommands;
+use bevy::prelude::*;
+use bevy_kira_audio::prelude::*;
+use std::time::Duration;
+
+/// Interactive demo: three effects on one channel, toggled with keyboard keys.
+///
+/// Controls:
+///   [1]              –  toggle looped sound on/off
+///   [2] / [3] / [4]  –  play a one-shot sound
+///   [F] / [D] / [R]  –  toggle Filter / Distortion / Reverb
+fn main() {
+    let mut track = AudioTrack::new();
+
+    let filter = track.add_effect(
+        FilterBuilder::new()
+            .mode(FilterMode::LowPass)
+            .cutoff(800.0)
+            .mix(0.0_f32),
+    );
+
+    let distortion = track.add_effect(
+        DistortionBuilder::new()
+            .kind(DistortionKind::SoftClip)
+            .drive(Decibels(20.0))
+            .mix(0.0_f32),
+    );
+
+    let reverb = track.add_effect(ReverbBuilder::new().feedback(0.8).damping(0.3).mix(0.0_f32));
+
+    App::new()
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_audio_channel_with_track::<EffectsChannel>(track)
+        .insert_resource(EffectsState {
+            filter,
+            distortion,
+            reverb,
+            filter_on: false,
+            distortion_on: false,
+            reverb_on: false,
+        })
+        .insert_resource(LoopState {
+            playing: false,
+            instance: None,
+        })
+        .add_systems(Startup, setup)
+        .add_systems(Update, (handle_input, update_status_ui))
+        .run();
+}
+
+#[derive(Resource)]
+struct EffectsChannel;
+
+#[derive(Resource)]
+struct EffectsState {
+    filter: FilterHandle,
+    distortion: DistortionHandle,
+    reverb: ReverbHandle,
+    filter_on: bool,
+    distortion_on: bool,
+    reverb_on: bool,
+}
+
+#[derive(Resource)]
+struct LoopState {
+    playing: bool,
+    instance: Option<Handle<AudioInstance>>,
+}
+
+#[derive(Resource)]
+struct SoundHandles {
+    loop_sound: Handle<AudioSource>,
+    one_shots: [Handle<AudioSource>; 3],
+}
+
+#[derive(Component, Default)]
+struct LoopStatusText;
+
+#[derive(Component, Default)]
+struct FilterStatusText;
+
+#[derive(Component, Default)]
+struct DistortionStatusText;
+
+#[derive(Component, Default)]
+struct ReverbStatusText;
+
+const COLOR_ON: Color = Color::linear_rgb(0.2, 0.9, 0.2);
+const COLOR_OFF: Color = Color::linear_rgb(0.45, 0.45, 0.45);
+const COLOR_LABEL: Color = Color::linear_rgb(0.7, 0.7, 0.7);
+const COLOR_KEY: Color = Color::linear_rgb(0.9, 0.8, 0.4);
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2d);
+
+    let font = asset_server.load("fonts/monogram.ttf");
+    commands.insert_resource(SoundHandles {
+        loop_sound: asset_server.load("sounds/loop.ogg"),
+        one_shots: [
+            asset_server.load("sounds/cooking.ogg"),
+            asset_server.load("sounds/plop.ogg"),
+            asset_server.load("sounds/sound.ogg"),
+        ],
+    });
+
+    let heading = TextFont {
+        font: font.clone().into(),
+        font_size: 36.0.into(),
+        ..default()
+    };
+    let normal = TextFont {
+        font: font.clone().into(),
+        font_size: 26.0.into(),
+        ..default()
+    };
+
+    commands
+        .spawn(Node {
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            flex_direction: FlexDirection::Column,
+            padding: UiRect::all(Val::Px(40.0)),
+            row_gap: Val::Px(6.0),
+            ..default()
+        })
+        .with_children(|p| {
+            text_line(p, "Multiple Effects Channel", &heading, Color::WHITE);
+            spacer(p, 20.0);
+
+            text_line(p, "Play sounds:", &normal, COLOR_LABEL);
+            status_line::<LoopStatusText>(p, "  [1] loop     OFF", &normal);
+            text_line(p, "  [2] cooking  [3] plop  [4] sound", &normal, COLOR_KEY);
+            spacer(p, 20.0);
+
+            text_line(p, "Toggle effects:", &normal, COLOR_LABEL);
+            status_line::<FilterStatusText>(p, "  [F] Filter   OFF", &normal);
+            status_line::<DistortionStatusText>(p, "  [D] Distort  OFF", &normal);
+            status_line::<ReverbStatusText>(p, "  [R] Reverb   OFF", &normal);
+        });
+}
+
+fn text_line(
+    parent: &mut RelatedSpawnerCommands<ChildOf>,
+    content: &str,
+    font: &TextFont,
+    color: Color,
+) {
+    parent.spawn((Text::new(content), font.clone(), TextColor(color)));
+}
+
+fn status_line<M: Component + Default>(
+    parent: &mut RelatedSpawnerCommands<ChildOf>,
+    content: &str,
+    font: &TextFont,
+) {
+    parent.spawn((
+        Text::new(content),
+        font.clone(),
+        TextColor(COLOR_OFF),
+        M::default(),
+    ));
+}
+
+fn spacer(parent: &mut RelatedSpawnerCommands<ChildOf>, height: f32) {
+    parent.spawn(Node {
+        height: Val::Px(height),
+        ..default()
+    });
+}
+
+fn handle_input(
+    keys: Res<ButtonInput<KeyCode>>,
+    channel: Res<AudioChannel<EffectsChannel>>,
+    sounds: Res<SoundHandles>,
+    audio_sources: Res<Assets<AudioSource>>,
+    mut effects: ResMut<EffectsState>,
+    mut loop_state: ResMut<LoopState>,
+    mut audio_instances: ResMut<Assets<AudioInstance>>,
+) {
+    let tween = AudioTween::linear(Duration::from_millis(100));
+
+    // Toggle loop
+    if keys.just_pressed(KeyCode::Digit1) {
+        loop_state.playing = !loop_state.playing;
+    }
+
+    if loop_state.playing {
+        if loop_state.instance.is_none() && audio_sources.get(&sounds.loop_sound).is_some() {
+            let handle = channel.play(sounds.loop_sound.clone()).looped().handle();
+            loop_state.instance = Some(handle);
+        }
+    } else if let Some(handle) = loop_state.instance.clone()
+        && let Some(mut instance) = audio_instances.get_mut(&handle)
+    {
+        instance.stop(AudioTween::default());
+        loop_state.instance = None;
+    }
+
+    // One-shot sounds
+    if keys.just_pressed(KeyCode::Digit2) {
+        channel.play(sounds.one_shots[0].clone());
+    }
+    if keys.just_pressed(KeyCode::Digit3) {
+        channel.play(sounds.one_shots[1].clone());
+    }
+    if keys.just_pressed(KeyCode::Digit4) {
+        channel.play(sounds.one_shots[2].clone());
+    }
+
+    // Toggle effects
+    if keys.just_pressed(KeyCode::KeyF) {
+        effects.filter_on = !effects.filter_on;
+        let mix = if effects.filter_on { 1.0_f32 } else { 0.0_f32 };
+        effects.filter.set_mix(mix, tween);
+    }
+    if keys.just_pressed(KeyCode::KeyD) {
+        effects.distortion_on = !effects.distortion_on;
+        let mix = if effects.distortion_on {
+            1.0_f32
+        } else {
+            0.0_f32
+        };
+        effects.distortion.set_mix(mix, tween);
+    }
+    if keys.just_pressed(KeyCode::KeyR) {
+        effects.reverb_on = !effects.reverb_on;
+        let mix = if effects.reverb_on { 0.5_f32 } else { 0.0_f32 };
+        effects.reverb.set_mix(mix, tween);
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn update_status_ui(
+    effects: Res<EffectsState>,
+    loop_state: Res<LoopState>,
+    mut loop_q: Query<
+        (&mut Text, &mut TextColor),
+        (
+            With<LoopStatusText>,
+            Without<FilterStatusText>,
+            Without<DistortionStatusText>,
+            Without<ReverbStatusText>,
+        ),
+    >,
+    mut filter_q: Query<
+        (&mut Text, &mut TextColor),
+        (
+            With<FilterStatusText>,
+            Without<LoopStatusText>,
+            Without<DistortionStatusText>,
+            Without<ReverbStatusText>,
+        ),
+    >,
+    mut distortion_q: Query<
+        (&mut Text, &mut TextColor),
+        (
+            With<DistortionStatusText>,
+            Without<LoopStatusText>,
+            Without<FilterStatusText>,
+            Without<ReverbStatusText>,
+        ),
+    >,
+    mut reverb_q: Query<
+        (&mut Text, &mut TextColor),
+        (
+            With<ReverbStatusText>,
+            Without<LoopStatusText>,
+            Without<FilterStatusText>,
+            Without<DistortionStatusText>,
+        ),
+    >,
+) {
+    if loop_state.is_changed() {
+        update_line(&mut loop_q, "  [1] loop  ", loop_state.playing);
+    }
+    if effects.is_changed() {
+        update_line(&mut filter_q, "  [F] Filter", effects.filter_on);
+        update_line(&mut distortion_q, "  [D] Distort", effects.distortion_on);
+        update_line(&mut reverb_q, "  [R] Reverb", effects.reverb_on);
+    }
+}
+
+fn update_line(
+    query: &mut Query<(&mut Text, &mut TextColor), impl bevy::ecs::query::QueryFilter>,
+    prefix: &str,
+    on: bool,
+) {
+    if let Ok((mut text, mut color)) = query.single_mut() {
+        let label = if on { "ON" } else { "OFF" };
+        *text = Text::new(format!("{}   {}", prefix, label));
+        color.0 = if on { COLOR_ON } else { COLOR_OFF };
+    }
+}

--- a/examples/peak_meter.rs
+++ b/examples/peak_meter.rs
@@ -1,0 +1,205 @@
+use bevy::prelude::*;
+use bevy_kira_audio::prelude::*;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// A custom effect that measures how loud the audio is, and reports it back to the ECS.
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, (setup_ui, play))
+        .add_systems(Update, update_meter)
+        .run();
+}
+
+// -- The effect ------------------------------------------------------------------------------
+
+/// The loudest sample seen since the value was last read, as `f32` bits.
+///
+/// `process` runs on the audio thread, so the level cannot be shared through a lock. An atomic
+/// keeps both sides wait-free.
+type SharedPeak = Arc<AtomicU32>;
+
+struct PeakMeter {
+    peak: SharedPeak,
+}
+
+impl Effect for PeakMeter {
+    fn process(&mut self, input: &mut [Frame], _dt: f64, _info: &Info) {
+        let peak = input
+            .iter()
+            .map(|frame| frame.left.abs().max(frame.right.abs()))
+            .fold(0.0f32, f32::max);
+
+        // Bevy renders far slower than audio is processed, so several buffers pass between reads.
+        // Accumulating the maximum makes sure short transients are not missed. For non-negative
+        // floats the bit patterns order the same way the values do, so `fetch_max` works on them.
+        self.peak.fetch_max(peak.to_bits(), Ordering::Relaxed);
+    }
+}
+
+/// Configures a [`PeakMeter`].
+struct PeakMeterBuilder;
+
+impl AudioEffect for PeakMeterBuilder {
+    type Handle = PeakMeterHandle;
+
+    fn build_effect(self) -> (Box<dyn Effect>, Self::Handle) {
+        let peak = SharedPeak::default();
+
+        (
+            Box::new(PeakMeter { peak: peak.clone() }),
+            PeakMeterHandle(peak),
+        )
+    }
+}
+
+/// Reads the measured level.
+#[derive(Resource)]
+struct PeakMeterHandle(SharedPeak);
+
+impl PeakMeterHandle {
+    /// The loudest sample since this method was last called, where `1.0` is full scale.
+    fn take_peak(&self) -> f32 {
+        f32::from_bits(self.0.swap(0, Ordering::Relaxed))
+    }
+}
+
+// -- Playback --------------------------------------------------------------------------------
+
+fn play(audio: Res<Audio>, asset_server: Res<AssetServer>, mut commands: Commands) {
+    let mut sound = audio.play(asset_server.load("sounds/loop.ogg"));
+    let meter = sound.add_effect(PeakMeterBuilder);
+    sound.looped();
+
+    commands.insert_resource(meter);
+}
+
+// -- The meter -------------------------------------------------------------------------------
+
+/// The quietest level the bar shows. Anything below this reads as empty.
+const FLOOR_DB: f32 = -60.0;
+
+/// How quickly the bar falls back down, the way the needle of a real meter drops.
+const FALL_DB_PER_SECOND: f32 = 36.0;
+
+#[derive(Component)]
+struct MeterBar {
+    /// Displayed level in dBFS, where `0.0` is full scale.
+    level_db: f32,
+}
+
+impl Default for MeterBar {
+    fn default() -> Self {
+        Self { level_db: FLOOR_DB }
+    }
+}
+
+#[derive(Component)]
+struct MeterLabel;
+
+fn update_meter(
+    time: Res<Time>,
+    meter: Res<PeakMeterHandle>,
+    mut bar: Single<(&mut MeterBar, &mut Node, &mut BackgroundColor)>,
+    mut label: Single<&mut Text, With<MeterLabel>>,
+) {
+    let (state, node, color) = &mut *bar;
+
+    // Audio is rendered in bursts, so some frames see no new samples at all. Levels are shown on
+    // a decibel scale, because that is how loudness is perceived: a linear bar spends almost all
+    // of its length on the loudest few decibels and looks broken for normal material.
+    let peak = meter.take_peak();
+    let peak_db = if peak > 0.0 {
+        20.0 * peak.log10()
+    } else {
+        FLOOR_DB
+    };
+
+    // Jump straight to a new peak, but ease back down, the way a real meter behaves.
+    state.level_db = if peak_db > state.level_db {
+        peak_db
+    } else {
+        (state.level_db - FALL_DB_PER_SECOND * time.delta_secs()).max(FLOOR_DB)
+    };
+
+    let fill = ((state.level_db - FLOOR_DB) / -FLOOR_DB).clamp(0.0, 1.0);
+    node.width = Val::Percent(fill * 100.0);
+    color.0 = if state.level_db > -3.0 {
+        Color::linear_rgb(0.9, 0.2, 0.2)
+    } else if state.level_db > -12.0 {
+        Color::linear_rgb(0.9, 0.8, 0.3)
+    } else {
+        Color::linear_rgb(0.3, 0.85, 0.4)
+    };
+
+    **label = Text::new(if state.level_db > FLOOR_DB {
+        format!("{:.1} dBFS", state.level_db)
+    } else {
+        "-inf dBFS".to_owned()
+    });
+}
+
+// -- UI --------------------------------------------------------------------------------------
+
+fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2d);
+
+    let font = TextFont {
+        font: asset_server.load("fonts/monogram.ttf").into(),
+        font_size: 32.0.into(),
+        ..default()
+    };
+
+    commands
+        .spawn(Node {
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            flex_direction: FlexDirection::Column,
+            justify_content: JustifyContent::Center,
+            padding: UiRect::all(Val::Px(60.0)),
+            row_gap: Val::Px(12.0),
+            ..default()
+        })
+        .with_children(|parent| {
+            parent.spawn((
+                Text::new("Peak meter (custom effect)"),
+                font.clone(),
+                TextColor(Color::WHITE),
+            ));
+            parent.spawn((
+                Text::new(format!("{FLOOR_DB:.0} dBFS to 0 dBFS")),
+                font.clone(),
+                TextColor(Color::linear_rgb(0.45, 0.45, 0.45)),
+            ));
+
+            // The track the bar grows inside of.
+            parent
+                .spawn((
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Px(48.0),
+                        ..default()
+                    },
+                    BackgroundColor(Color::linear_rgb(0.12, 0.12, 0.14)),
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Node {
+                            width: Val::Percent(0.0),
+                            height: Val::Percent(100.0),
+                            ..default()
+                        },
+                        BackgroundColor(Color::linear_rgb(0.3, 0.85, 0.4)),
+                        MeterBar::default(),
+                    ));
+                });
+
+            parent.spawn((
+                Text::new("-inf dBFS"),
+                font,
+                TextColor(Color::linear_rgb(0.6, 0.6, 0.6)),
+                MeterLabel,
+            ));
+        });
+}

--- a/examples/reverb.rs
+++ b/examples/reverb.rs
@@ -1,0 +1,53 @@
+use bevy::prelude::*;
+use bevy_kira_audio::prelude::*;
+use std::time::Duration;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_systems(Startup, play)
+        .add_systems(Update, toggle_reverb)
+        .run();
+}
+
+fn play(audio: Res<Audio>, asset_server: Res<AssetServer>, mut commands: Commands) {
+    let mut cmd = audio.play(asset_server.load("sounds/cooking.ogg"));
+    let reverb = cmd.add_effect(
+        ReverbBuilder::new()
+            .feedback(0.85)
+            .damping(0.2)
+            .mix(0.0_f32), // start dry
+    );
+    cmd.looped();
+
+    commands.insert_resource(ReverbState {
+        handle: reverb,
+        on: false,
+        timer: Timer::new(Duration::from_secs(3), TimerMode::Repeating),
+    });
+}
+
+fn toggle_reverb(time: Res<Time>, mut state: ResMut<ReverbState>) {
+    state.timer.tick(time.delta());
+    if !state.timer.just_finished() {
+        return;
+    }
+
+    state.on = !state.on;
+    let transition = AudioTween::linear(Duration::from_millis(80));
+
+    if state.on {
+        state.handle.set_mix(0.7_f32, transition);
+        info!("Reverb ON");
+    } else {
+        state.handle.set_mix(0.0_f32, transition);
+        info!("Reverb OFF");
+    }
+}
+
+#[derive(Resource)]
+struct ReverbState {
+    handle: ReverbHandle,
+    on: bool,
+    timer: Timer,
+}

--- a/examples/reverb_channel.rs
+++ b/examples/reverb_channel.rs
@@ -1,0 +1,69 @@
+use bevy::prelude::*;
+use bevy_kira_audio::prelude::*;
+use std::time::Duration;
+
+fn main() {
+    let mut track = AudioTrack::new();
+    let _reverb = track.add_effect(
+        ReverbBuilder::new()
+            .feedback(0.85)
+            .damping(0.2)
+            .mix(0.5_f32),
+    );
+
+    App::new()
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_audio_channel_with_track::<ReverbChannel>(track)
+        .add_systems(Startup, start_playback)
+        .add_systems(Update, play_next_sound)
+        .run();
+}
+
+fn start_playback(
+    channel: Res<AudioChannel<ReverbChannel>>,
+    asset_server: Res<AssetServer>,
+    mut commands: Commands,
+) {
+    // Start with a looped sound immediately
+    channel.play(asset_server.load("sounds/loop.ogg")).looped();
+
+    // Queue the one-shot sounds to play in sequence
+    commands.insert_resource(SoundQueue {
+        sounds: vec![
+            asset_server.load("sounds/cooking.ogg"),
+            asset_server.load("sounds/plop.ogg"),
+            asset_server.load("sounds/sound.ogg"),
+        ],
+        index: 0,
+        timer: Timer::new(Duration::from_secs(3), TimerMode::Repeating),
+    });
+}
+
+fn play_next_sound(
+    time: Res<Time>,
+    channel: Res<AudioChannel<ReverbChannel>>,
+    mut queue: ResMut<SoundQueue>,
+) {
+    queue.timer.tick(time.delta());
+    if !queue.timer.just_finished() {
+        return;
+    }
+
+    let sound = &queue.sounds[queue.index % queue.sounds.len()];
+    channel.play(sound.clone());
+    info!(
+        "Playing sound {} with reverb",
+        queue.index % queue.sounds.len()
+    );
+    queue.index += 1;
+}
+
+#[derive(Resource)]
+struct ReverbChannel;
+
+#[derive(Resource)]
+struct SoundQueue {
+    sounds: Vec<bevy::asset::Handle<AudioSource>>,
+    index: usize,
+    timer: Timer,
+}

--- a/examples/stacked_effects.rs
+++ b/examples/stacked_effects.rs
@@ -1,0 +1,193 @@
+use bevy::prelude::*;
+use bevy_kira_audio::prelude::*;
+
+fn main() {
+    // The reverb applies to every sound played on the hall channel, including sounds that bring
+    // effects of their own.
+    let hall =
+        AudioTrack::new().with_effect(ReverbBuilder::new().feedback(0.9).damping(0.1).mix(0.6_f32));
+
+    App::new()
+        .add_plugins((DefaultPlugins, AudioPlugin))
+        .add_audio_channel_with_track::<HallChannel>(hall)
+        .init_resource::<Playing>()
+        .add_systems(Startup, setup)
+        .add_systems(Update, (play, update_status).chain())
+        .run();
+}
+
+/// One way of playing the loop: through the hall channel, through a low-pass, or both.
+struct Variant {
+    key: KeyCode,
+    /// Play on the channel carrying the reverb rather than on the main channel.
+    hall: bool,
+    /// Give the sound a low-pass filter of its own.
+    muffle: bool,
+    label: &'static str,
+    routing: &'static str,
+}
+
+const VARIANTS: [Variant; 4] = [
+    Variant {
+        key: KeyCode::Digit1,
+        hall: false,
+        muffle: false,
+        label: "[1] dry",
+        routing: "loop -> main track",
+    },
+    Variant {
+        key: KeyCode::Digit2,
+        hall: false,
+        muffle: true,
+        label: "[2] muffled",
+        routing: "loop -> low-pass -> main track",
+    },
+    Variant {
+        key: KeyCode::Digit3,
+        hall: true,
+        muffle: false,
+        label: "[3] hall",
+        routing: "loop -> reverb -> main track",
+    },
+    Variant {
+        key: KeyCode::Digit4,
+        hall: true,
+        muffle: true,
+        label: "[4] both",
+        routing: "loop -> low-pass -> reverb -> main track",
+    },
+];
+
+const COLOR_PLAYING: Color = Color::linear_rgb(0.3, 0.85, 0.4);
+const COLOR_IDLE: Color = Color::linear_rgb(0.45, 0.45, 0.45);
+
+#[derive(Resource)]
+struct Loop(Handle<AudioSource>);
+
+/// The variant that is currently looping, if any.
+#[derive(Resource, Default)]
+struct Playing(Option<&'static Variant>);
+
+#[derive(Component)]
+struct StatusText;
+
+fn play(
+    keys: Res<ButtonInput<KeyCode>>,
+    audio: Res<Audio>,
+    hall: Res<AudioChannel<HallChannel>>,
+    sound: Res<Loop>,
+    mut playing: ResMut<Playing>,
+) {
+    for variant in &VARIANTS {
+        if !keys.just_pressed(variant.key) {
+            continue;
+        }
+
+        audio.stop();
+        hall.stop();
+
+        // One statement per variant, each playing the same loop. `with_effect` gives the sound an
+        // effect of its own; playing on the hall channel adds that channel's reverb on top.
+        match (variant.hall, variant.muffle) {
+            // Dry: no effects at all.
+            (false, false) => {
+                audio.play(sound.0.clone()).looped();
+            }
+            // The sound's own effect only.
+            (false, true) => {
+                audio.play(sound.0.clone()).with_effect(low_pass()).looped();
+            }
+            // The channel's effect only.
+            (true, false) => {
+                hall.play(sound.0.clone()).looped();
+            }
+            // Both: the sound's own effect first, then the channel's.
+            (true, true) => {
+                hall.play(sound.0.clone()).with_effect(low_pass()).looped();
+            }
+        }
+
+        playing.0 = Some(variant);
+        info!("Playing {}: {}", variant.label, variant.routing);
+    }
+}
+
+/// The effect a sound brings itself: a low-pass leaving only the bass.
+fn low_pass() -> FilterBuilder {
+    FilterBuilder::new()
+        .mode(FilterMode::LowPass)
+        .cutoff(400.0)
+        .mix(1.0_f32)
+}
+
+fn update_status(
+    playing: Res<Playing>,
+    mut status: Single<(&mut Text, &mut TextColor), With<StatusText>>,
+) {
+    if !playing.is_changed() {
+        return;
+    }
+
+    let (text, color) = &mut *status;
+    match playing.0 {
+        Some(variant) => {
+            **text = Text::new(format!("{}  -  {}", variant.label, variant.routing));
+            color.0 = COLOR_PLAYING;
+        }
+        None => {
+            **text = Text::new("press [1], [2], [3] or [4]");
+            color.0 = COLOR_IDLE;
+        }
+    }
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2d);
+    commands.insert_resource(Loop(asset_server.load("sounds/loop.ogg")));
+
+    let font = asset_server.load("fonts/monogram.ttf");
+    let normal = TextFont {
+        font: font.clone().into(),
+        font_size: 26.0.into(),
+        ..default()
+    };
+
+    commands
+        .spawn(Node {
+            flex_direction: FlexDirection::Column,
+            padding: UiRect::all(Val::Px(40.0)),
+            row_gap: Val::Px(24.0),
+            ..default()
+        })
+        .with_children(|parent| {
+            parent.spawn((
+                Text::new("Stacked effects"),
+                TextFont {
+                    font: font.into(),
+                    font_size: 36.0.into(),
+                    ..default()
+                },
+                TextColor(Color::WHITE),
+            ));
+            parent.spawn((
+                Text::new(
+                    "The same loop through a per-sound low-pass, a channel reverb, or both.\n\n\
+                     [1] dry\n\
+                     [2] muffled  -  the sound's own low-pass\n\
+                     [3] hall     -  the channel's reverb\n\
+                     [4] both     -  low-pass first, then the same reverb",
+                ),
+                normal.clone(),
+                TextColor(Color::linear_rgb(0.7, 0.7, 0.7)),
+            ));
+            parent.spawn((
+                Text::new("press [1], [2], [3] or [4]"),
+                normal,
+                TextColor(COLOR_IDLE),
+                StatusText,
+            ));
+        });
+}
+
+#[derive(Resource)]
+struct HallChannel;

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -13,6 +13,7 @@ fn main() {
         // We need to increase the queue sizes of the audio backend.
         .insert_resource(AudioSettings {
             sound_capacity: 8192,
+            ..default()
         })
         .add_plugins((DefaultPlugins, AudioPlugin))
         .add_systems(Startup, prepare)

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -324,9 +324,13 @@ impl<'a> PlayAudioCommand<'a> {
     /// The returned handle can be stored and used to modify the effect at runtime.
     ///
     /// **Note:** Per-instance effects and channel-level effects (via
-    /// [`add_audio_channel_with_track`](AudioApp::add_audio_channel_with_track)) are independent.
-    /// When a sound has per-instance effects, it plays on its own sub-track and bypasses the
-    /// channel's effect chain. That sub-track outlives the sound, so effects that ring out are
+    /// [`add_audio_channel_with_track`](AudioApp::add_audio_channel_with_track)) stack. When the
+    /// channel has a track of its own, this sound's sub-track is nested inside it, so the sound is
+    /// processed by its own effects first and by the channel's effects afterwards. Each such
+    /// sub-track takes one of the channel track's
+    /// [`sub_track_capacity`](AudioTrack::sub_track_capacity) slots, or one of
+    /// [`AudioSettings::sub_track_capacity`](crate::AudioSettings::sub_track_capacity) for
+    /// channels without a track. The sub-track outlives the sound, so effects that ring out are
     /// not cut short; see [`with_effect_tail`](Self::with_effect_tail).
     ///
     /// ```no_run

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,9 +1,11 @@
 //! Common audio types
 
 use crate::AudioSystemSet;
-use crate::audio_output::{play_audio_channel, update_instance_states};
+use crate::audio_output::{AudioOutput, play_audio_channel, update_instance_states};
 use crate::channel::AudioCommandQue;
+use crate::channel::Channel;
 use crate::channel::typed::AudioChannel;
+use crate::effect::{AudioEffect, AudioTrack};
 use crate::instance::AudioInstance;
 use crate::source::AudioSource;
 use bevy::app::{App, PreUpdate};
@@ -11,13 +13,24 @@ use bevy::asset::Handle;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs;
+use bevy::log::error;
 use bevy::prelude::{PostUpdate, default};
 use kira::sound::EndPosition;
 use kira::sound::static_sound::{StaticSoundData, StaticSoundHandle};
 use kira::{Decibels, Panning, Value};
+use parking_lot::Mutex;
+use std::any::TypeId;
+use std::fmt;
 use std::marker::PhantomData;
+use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
+
+/// A thread-safe, shareable wrapper around an [`AudioTrack`].
+///
+/// Used to pass an `AudioTrack` (which is `Send` but not `Sync`) through
+/// Bevy's command queue by wrapping it in `Arc<Mutex<Option<AudioTrack>>>`.
+pub(crate) type SharedAudioTrack = Arc<Mutex<Option<AudioTrack>>>;
 
 #[derive(Debug)]
 pub(crate) enum AudioCommand {
@@ -30,7 +43,7 @@ pub(crate) enum AudioCommand {
     Resume(Option<AudioTween>),
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default)]
 pub(crate) struct PartialSoundSettings {
     pub(crate) loop_start: Option<f64>,
     pub(crate) loop_end: Option<f64>,
@@ -42,6 +55,25 @@ pub(crate) struct PartialSoundSettings {
     pub(crate) paused: bool,
     pub(crate) fade_in: Option<AudioTween>,
     pub(crate) emitter: Option<Entity>,
+    pub(crate) track: Option<SharedAudioTrack>,
+}
+
+impl fmt::Debug for PartialSoundSettings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PartialSoundSettings")
+            .field("loop_start", &self.loop_start)
+            .field("loop_end", &self.loop_end)
+            .field("volume", &self.volume)
+            .field("playback_rate", &self.playback_rate)
+            .field("start_position", &self.start_position)
+            .field("panning", &self.panning)
+            .field("reverse", &self.reverse)
+            .field("paused", &self.paused)
+            .field("fade_in", &self.fade_in)
+            .field("emitter", &self.emitter)
+            .field("track", &self.track.as_ref().map(|_| "..."))
+            .finish()
+    }
 }
 
 /// Different kinds of easing for fade-in and fade-out
@@ -50,7 +82,7 @@ pub type AudioEasing = kira::Easing;
 /// A tween for audio transitions
 ///
 /// Use the default for almost instantaneous transitions without audio artifacts
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct AudioTween {
     duration: Duration,
     easing: AudioEasing,
@@ -283,6 +315,59 @@ impl<'a> PlayAudioCommand<'a> {
         self.settings.emitter = Some(emitter_entity);
         self
     }
+
+    /// Add an audio effect to this sound instance and return its handle for runtime control.
+    ///
+    /// The effect will be applied via a dedicated sub-track created for this sound instance.
+    /// The returned handle can be stored and used to modify the effect at runtime.
+    ///
+    /// **Note:** Per-instance effects and channel-level effects (via
+    /// [`add_audio_channel_with_track`](AudioApp::add_audio_channel_with_track)) are independent.
+    /// When a sound has per-instance effects, it plays on its own sub-track and bypasses the
+    /// channel's effect chain.
+    ///
+    /// ```no_run
+    /// # use bevy::prelude::*;
+    /// # use bevy_kira_audio::prelude::*;
+    ///
+    /// fn play(audio: Res<Audio>, asset_server: Res<AssetServer>) {
+    ///     let mut cmd = audio.play(asset_server.load("sounds/loop.ogg"));
+    ///     let filter_handle = cmd.add_effect(FilterBuilder::new());
+    ///     cmd.looped();
+    /// }
+    /// ```
+    pub fn add_effect<E: AudioEffect>(&mut self, effect: E) -> E::Handle {
+        let shared = self
+            .settings
+            .track
+            .get_or_insert_with(|| Arc::new(Mutex::new(None)));
+        let mut guard = shared.lock();
+
+        guard
+            .get_or_insert_with(AudioTrack::for_instance)
+            .add_effect(effect)
+    }
+
+    /// Add an audio effect to this sound instance (chainable).
+    ///
+    /// Like [`add_effect`](Self::add_effect), but discards the effect handle
+    /// and returns `&mut Self` for method chaining.
+    ///
+    /// ```no_run
+    /// # use bevy::prelude::*;
+    /// # use bevy_kira_audio::prelude::*;
+    ///
+    /// fn play(audio: Res<Audio>, asset_server: Res<AssetServer>) {
+    ///     audio.play(asset_server.load("sounds/loop.ogg"))
+    ///         .with_effect(FilterBuilder::new())
+    ///         .with_effect(ReverbBuilder::new())
+    ///         .looped();
+    /// }
+    /// ```
+    pub fn with_effect<E: AudioEffect>(&mut self, effect: E) -> &mut Self {
+        self.add_effect(effect);
+        self
+    }
 }
 
 pub(crate) enum TweenCommandKind {
@@ -461,6 +546,7 @@ impl From<&StaticSoundHandle> for PlaybackState {
 /// Extension trait to add new audio channels to the application
 pub trait AudioApp {
     /// Add a new audio channel to the application
+    /// Adding a channel that is already registered does nothing.
     ///
     /// ```no_run
     /// use bevy::prelude::*;
@@ -483,10 +569,45 @@ pub trait AudioApp {
     /// struct Background;
     /// ```
     fn add_audio_channel<T: Resource>(&mut self) -> &mut Self;
+
+    /// Add a new audio channel with a custom [`AudioTrack`] for channel-level effects.
+    ///
+    /// Effects added to the `AudioTrack` will apply to all sounds played on this channel.
+    /// You can use [`AudioTrack::add_effect`] to add effects and store the returned handles
+    /// as Bevy resources for runtime control.
+    ///
+    /// [`AudioPlugin`](crate::AudioPlugin) must be added before calling this method. If it has not
+    /// been added yet, an error is logged and the channel is added without the track or its effects.
+    ///
+    /// ```no_run
+    /// use bevy::prelude::*;
+    /// use bevy_kira_audio::prelude::*;
+    ///
+    /// #[derive(Resource)]
+    /// struct MusicChannel;
+    ///
+    /// fn main() {
+    ///     let mut track = AudioTrack::new();
+    ///     let _reverb = track.add_effect(ReverbBuilder::new());
+    ///
+    ///     App::new()
+    ///         .add_plugins(DefaultPlugins)
+    ///         .add_plugins(AudioPlugin)
+    ///         .add_audio_channel_with_track::<MusicChannel>(track)
+    ///         .run();
+    /// }
+    /// ```
+    fn add_audio_channel_with_track<T: Resource>(&mut self, track: AudioTrack) -> &mut Self;
 }
 
 impl AudioApp for App {
     fn add_audio_channel<T: Resource>(&mut self) -> &mut Self {
+        // Registering a channel twice would run its systems twice per frame and drop anything
+        // already queued on the channel.
+        if self.world().contains_resource::<AudioChannel<T>>() {
+            return self;
+        }
+
         self.add_systems(
             PostUpdate,
             play_audio_channel::<T>.in_set(AudioSystemSet::PlayTypedChannels),
@@ -496,5 +617,21 @@ impl AudioApp for App {
             update_instance_states::<T>.after(AudioSystemSet::InstanceCleanup),
         )
         .insert_resource(AudioChannel::<T>::default())
+    }
+
+    fn add_audio_channel_with_track<T: Resource>(&mut self, track: AudioTrack) -> &mut Self {
+        self.add_audio_channel::<T>();
+
+        if let Some(mut audio_output) = self.world_mut().get_non_send_mut::<AudioOutput>() {
+            audio_output.create_channel_track(Channel::Typed(TypeId::of::<T>()), track);
+        } else {
+            error!(
+                "Failed to add audio track for channel `{}`: `AudioPlugin` must be added before \
+                 `add_audio_channel_with_track`; the channel was added without the track",
+                std::any::type_name::<T>(),
+            );
+        }
+
+        self
     }
 }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -56,6 +56,7 @@ pub(crate) struct PartialSoundSettings {
     pub(crate) fade_in: Option<AudioTween>,
     pub(crate) emitter: Option<Entity>,
     pub(crate) track: Option<SharedAudioTrack>,
+    pub(crate) effect_tail: Option<Duration>,
 }
 
 impl fmt::Debug for PartialSoundSettings {
@@ -72,6 +73,7 @@ impl fmt::Debug for PartialSoundSettings {
             .field("fade_in", &self.fade_in)
             .field("emitter", &self.emitter)
             .field("track", &self.track.as_ref().map(|_| "..."))
+            .field("effect_tail", &self.effect_tail)
             .finish()
     }
 }
@@ -324,7 +326,8 @@ impl<'a> PlayAudioCommand<'a> {
     /// **Note:** Per-instance effects and channel-level effects (via
     /// [`add_audio_channel_with_track`](AudioApp::add_audio_channel_with_track)) are independent.
     /// When a sound has per-instance effects, it plays on its own sub-track and bypasses the
-    /// channel's effect chain.
+    /// channel's effect chain. That sub-track outlives the sound, so effects that ring out are
+    /// not cut short; see [`with_effect_tail`](Self::with_effect_tail).
     ///
     /// ```no_run
     /// # use bevy::prelude::*;
@@ -366,6 +369,29 @@ impl<'a> PlayAudioCommand<'a> {
     /// ```
     pub fn with_effect<E: AudioEffect>(&mut self, effect: E) -> &mut Self {
         self.add_effect(effect);
+        self
+    }
+
+    /// Set how long this sound's effects keep running after the sound itself has stopped.
+    ///
+    /// Reverb and delay go on producing sound after their input has gone quiet. The track carrying
+    /// this sound's effects is kept alive for this long after playback stops, so those tails are
+    /// not cut off. Defaults to [`DEFAULT_EFFECT_TAIL`](crate::effect::DEFAULT_EFFECT_TAIL).
+    ///
+    /// ```no_run
+    /// # use bevy::prelude::*;
+    /// # use bevy_kira_audio::prelude::*;
+    /// # use std::time::Duration;
+    ///
+    /// fn play(audio: Res<Audio>, asset_server: Res<AssetServer>) {
+    ///     audio.play(asset_server.load("sounds/loop.ogg"))
+    ///         .with_effect(ReverbBuilder::new().feedback(0.95))
+    ///         .with_effect_tail(Duration::from_secs(6));
+    /// }
+    /// ```
+    pub fn with_effect_tail(&mut self, tail: Duration) -> &mut Self {
+        self.settings.effect_tail = Some(tail);
+
         self
     }
 }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -22,15 +22,14 @@ use parking_lot::Mutex;
 use std::any::TypeId;
 use std::fmt;
 use std::marker::PhantomData;
-use std::sync::Arc;
+use std::mem;
 use std::time::Duration;
 use uuid::Uuid;
 
-/// A thread-safe, shareable wrapper around an [`AudioTrack`].
-///
-/// Used to pass an `AudioTrack` (which is `Send` but not `Sync`) through
-/// Bevy's command queue by wrapping it in `Arc<Mutex<Option<AudioTrack>>>`.
-pub(crate) type SharedAudioTrack = Arc<Mutex<Option<AudioTrack>>>;
+/// The slot carrying one sound instance's own [`AudioTrack`] to the audio output.
+/// Wrapped because the audio output must take the `Send`-but-not-`Sync` track out through
+/// a shared reference to the command queue.
+pub(crate) type InstanceTrackSlot = Mutex<Option<Box<AudioTrack>>>;
 
 #[derive(Debug)]
 pub(crate) enum AudioCommand {
@@ -43,7 +42,7 @@ pub(crate) enum AudioCommand {
     Resume(Option<AudioTween>),
 }
 
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub(crate) struct PartialSoundSettings {
     pub(crate) loop_start: Option<f64>,
     pub(crate) loop_end: Option<f64>,
@@ -55,7 +54,7 @@ pub(crate) struct PartialSoundSettings {
     pub(crate) paused: bool,
     pub(crate) fade_in: Option<AudioTween>,
     pub(crate) emitter: Option<Entity>,
-    pub(crate) track: Option<SharedAudioTrack>,
+    pub(crate) track: InstanceTrackSlot,
     pub(crate) effect_tail: Option<Duration>,
 }
 
@@ -72,7 +71,13 @@ impl fmt::Debug for PartialSoundSettings {
             .field("paused", &self.paused)
             .field("fade_in", &self.fade_in)
             .field("emitter", &self.emitter)
-            .field("track", &self.track.as_ref().map(|_| "..."))
+            .field(
+                "track",
+                &self
+                    .track
+                    .try_lock()
+                    .map_or(Some("<locked>"), |track| track.as_ref().map(|_| "...")),
+            )
             .field("effect_tail", &self.effect_tail)
             .finish()
     }
@@ -182,7 +187,7 @@ impl PartialSoundSettings {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct PlayAudioSettings {
     pub(crate) instance_handle: Handle<AudioInstance>,
     pub(crate) source: Handle<AudioSource>,
@@ -190,11 +195,12 @@ pub struct PlayAudioSettings {
 }
 
 impl<'a> From<&mut PlayAudioCommand<'a>> for PlayAudioSettings {
+    /// Takes the settings out of the command, which is only ever done as the command is dropped.
     fn from(command: &mut PlayAudioCommand<'a>) -> Self {
         PlayAudioSettings {
             instance_handle: command.instance_handle.clone(),
             source: command.source.clone(),
-            settings: command.settings.clone(),
+            settings: mem::take(&mut command.settings),
         }
     }
 }
@@ -344,14 +350,10 @@ impl<'a> PlayAudioCommand<'a> {
     /// }
     /// ```
     pub fn add_effect<E: AudioEffect>(&mut self, effect: E) -> E::Handle {
-        let shared = self
-            .settings
+        self.settings
             .track
-            .get_or_insert_with(|| Arc::new(Mutex::new(None)));
-        let mut guard = shared.lock();
-
-        guard
-            .get_or_insert_with(AudioTrack::for_instance)
+            .get_mut()
+            .get_or_insert_with(|| Box::new(AudioTrack::for_instance()))
             .add_effect(effect)
     }
 

--- a/src/audio_output.rs
+++ b/src/audio_output.rs
@@ -8,15 +8,17 @@ use crate::backend_settings::AudioSettings;
 use crate::channel::dynamic::DynamicAudioChannels;
 use crate::channel::typed::AudioChannel;
 use crate::channel::{Channel, ChannelState};
+use crate::effect::AudioTrack;
 use crate::instance::AudioInstance;
 use crate::source::AudioSource;
-use bevy::asset::{Assets, Handle};
+use bevy::asset::{AssetId, Assets, Handle};
 use bevy::ecs::change_detection::{NonSendMut, ResMut};
 use bevy::ecs::resource::Resource;
 use bevy::ecs::system::{NonSend, Res};
 use bevy::ecs::world::{FromWorld, World};
 use bevy::log::warn;
 use kira::backend::{Backend, DefaultBackend};
+use kira::track::TrackHandle;
 use kira::{AudioManager, Panning};
 use kira::{Decibels, PlaybackRate};
 use std::collections::HashMap;
@@ -29,6 +31,8 @@ pub(crate) struct AudioOutput<B: Backend = DefaultBackend> {
     manager: Option<AudioManager<B>>,
     instances: HashMap<Channel, Vec<Handle<AudioInstance>>>,
     channels: HashMap<Channel, ChannelState>,
+    channel_tracks: HashMap<Channel, TrackHandle>,
+    instance_tracks: HashMap<AssetId<AudioInstance>, TrackHandle>,
 }
 
 impl FromWorld for AudioOutput {
@@ -43,6 +47,8 @@ impl FromWorld for AudioOutput {
             manager: manager.ok(),
             instances: HashMap::default(),
             channels: HashMap::default(),
+            channel_tracks: HashMap::default(),
+            instance_tracks: HashMap::default(),
         }
     }
 }
@@ -218,7 +224,38 @@ impl<B: Backend> AudioOutput<B> {
             sound.settings.playback_rate = kira::Value::Fixed(PlaybackRate(0.0));
         }
         partial_sound_settings.apply(&mut sound);
-        let sound_handle = self.manager.as_mut().unwrap().play(sound);
+
+        // Determine where to play the sound based on per-instance and channel tracks
+        let instance_track = partial_sound_settings
+            .track
+            .as_ref()
+            .and_then(|shared| shared.lock().take());
+
+        let sound_handle = if let Some(track) = instance_track {
+            // Per-instance effects: create a sub-track for this instance
+            let manager = self.manager.as_mut().unwrap();
+            match manager.add_sub_track(track.into_inner()) {
+                Ok(mut track_handle) => {
+                    let result = track_handle.play(sound);
+                    if result.is_ok() {
+                        self.instance_tracks
+                            .insert(instance_handle.id(), track_handle);
+                    }
+                    result
+                }
+                Err(error) => {
+                    warn!("Failed to create sub-track: {:?}", error);
+                    return AudioCommandResult::Ok;
+                }
+            }
+        } else if let Some(track_handle) = self.channel_tracks.get_mut(channel) {
+            // Channel-level effects: play on the channel's sub-track
+            track_handle.play(sound)
+        } else {
+            // No effects: play on the main track
+            self.manager.as_mut().unwrap().play(sound)
+        };
+
         if let Err(error) = sound_handle {
             warn!("Failed to play sound due to {:?}", error);
             return AudioCommandResult::Ok;
@@ -362,12 +399,39 @@ impl<B: Backend> AudioOutput<B> {
         }
     }
 
+    pub(crate) fn create_channel_track(&mut self, channel: Channel, track: AudioTrack) {
+        if let Some(manager) = self.manager.as_mut() {
+            match manager.add_sub_track(track.into_inner()) {
+                Ok(track_handle) => {
+                    if self.channel_tracks.insert(channel, track_handle).is_some() {
+                        warn!(
+                            "An audio track was already registered for this channel and has been \
+                             replaced. Effect handles for the previous track will no longer control \
+                             this channel. Ensure `add_audio_channel_with_track` is called only once \
+                             per channel type."
+                        );
+                    }
+                }
+                Err(error) => {
+                    warn!("Failed to create channel sub-track: {:?}", error);
+                }
+            }
+        }
+    }
+
     pub(crate) fn cleanup_stopped_instances(&mut self, instances: &mut Assets<AudioInstance>) {
         for handles in self.instances.values_mut() {
             handles.retain(|handle| {
                 if let Some(instance) = instances.get(handle) {
-                    instance.handle.state() != kira::sound::PlaybackState::Stopped
+                    if instance.handle.state() == kira::sound::PlaybackState::Stopped {
+                        // Drop the per-instance track handle (kira will clean up the sub-track)
+                        self.instance_tracks.remove(&handle.id());
+                        false
+                    } else {
+                        true
+                    }
                 } else {
+                    self.instance_tracks.remove(&handle.id());
                     false
                 }
             });
@@ -455,6 +519,8 @@ mod test {
             manager: AudioManager::new(AudioManagerSettings::<MockBackend>::default()).ok(),
             instances: HashMap::default(),
             channels: HashMap::default(),
+            channel_tracks: HashMap::default(),
+            instance_tracks: HashMap::default(),
         };
         let audio_handle_one: Handle<AudioSource> =
             Handle::<AudioSource>::Uuid(Uuid::new_v4(), PhantomData);
@@ -501,6 +567,8 @@ mod test {
             manager: AudioManager::new(AudioManagerSettings::<MockBackend>::default()).ok(),
             instances: HashMap::default(),
             channels: HashMap::default(),
+            channel_tracks: HashMap::default(),
+            instance_tracks: HashMap::default(),
         };
         let audio_handle_one: Handle<AudioSource> =
             Handle::<AudioSource>::Uuid(Uuid::new_v4(), PhantomData);

--- a/src/audio_output.rs
+++ b/src/audio_output.rs
@@ -18,6 +18,7 @@ use bevy::ecs::system::{NonSend, Res};
 use bevy::ecs::world::{FromWorld, World};
 use bevy::log::warn;
 use bevy::platform::time::Instant;
+use kira::ResourceLimitReached;
 use kira::backend::{Backend, DefaultBackend};
 use kira::track::TrackHandle;
 use kira::{AudioManager, Panning};
@@ -275,8 +276,7 @@ impl<B: Backend> AudioOutput<B> {
 
         let sound_handle = if let Some(track) = instance_track {
             // Per-instance effects: create a sub-track for this instance
-            let manager = self.manager.as_mut().unwrap();
-            match manager.add_sub_track(track.into_inner()) {
+            match self.add_instance_track(channel, track) {
                 Ok(mut track_handle) => {
                     let result = track_handle.play(sound);
                     if result.is_ok() {
@@ -444,6 +444,27 @@ impl<B: Backend> AudioOutput<B> {
         }
     }
 
+    /// Create the sub-track carrying one sound's own effects.
+    ///
+    /// The track is nested under the channel's track when the channel has one, so that the
+    /// channel's effects still run after this sound's. Kira processes a track's children before
+    /// the track's own effects, which makes the resulting chain sound → instance effects →
+    /// channel effects → main track. Channels without a track of their own attach it directly to
+    /// the main track instead.
+    fn add_instance_track(
+        &mut self,
+        channel: &Channel,
+        track: AudioTrack,
+    ) -> Result<TrackHandle, ResourceLimitReached> {
+        let track = track.into_inner();
+
+        if let Some(channel_track) = self.channel_tracks.get_mut(channel) {
+            channel_track.add_sub_track(track)
+        } else {
+            self.manager.as_mut().unwrap().add_sub_track(track)
+        }
+    }
+
     pub(crate) fn create_channel_track(&mut self, channel: Channel, track: AudioTrack) {
         if let Some(manager) = self.manager.as_mut() {
             match manager.add_sub_track(track.into_inner()) {
@@ -544,12 +565,17 @@ mod test {
 
     use super::*;
     use crate::channel::AudioControl;
-    use crate::{Audio, AudioPlugin};
+    use crate::effect::{AudioEffect, Effect, FilterBuilder, Info, ReverbBuilder};
+    use crate::{Audio, AudioPlugin, PlayAudioCommand};
     use bevy::asset::AssetPlugin;
     use bevy::prelude::*;
     use kira::AudioManagerSettings;
-    use kira::backend::mock::MockBackend;
+    use kira::Frame;
+    use kira::backend::mock::{MockBackend, MockBackendSettings};
+    use kira::sound::static_sound::{StaticSoundData, StaticSoundSettings};
     use kira::track::TrackBuilder;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use uuid::Uuid;
 
     fn instance_track(tail: Duration) -> InstanceTrack {
@@ -557,6 +583,117 @@ mod test {
             AudioManager::new(AudioManagerSettings::<MockBackend>::default()).unwrap();
 
         InstanceTrack::new(manager.add_sub_track(TrackBuilder::new()).unwrap(), tail)
+    }
+
+    const SAMPLE_RATE: u32 = 44_100;
+
+    fn audio_output() -> AudioOutput<MockBackend> {
+        let settings = AudioManagerSettings::<MockBackend> {
+            // The mock backend renders at 1 Hz by default, which is too coarse to play a sound.
+            backend_settings: MockBackendSettings {
+                sample_rate: SAMPLE_RATE,
+            },
+            ..default()
+        };
+
+        AudioOutput {
+            manager: AudioManager::new(settings).ok(),
+            instances: HashMap::default(),
+            channels: HashMap::default(),
+            channel_tracks: HashMap::default(),
+            instance_tracks: HashMap::default(),
+        }
+    }
+
+    /// A second of audio at full amplitude, so that effects can tell it from silence.
+    fn audio_source() -> AudioSource {
+        AudioSource {
+            sound: StaticSoundData {
+                sample_rate: SAMPLE_RATE,
+                frames: Arc::from(vec![Frame::from_mono(1.0); SAMPLE_RATE as usize]),
+                settings: StaticSoundSettings::default(),
+                slice: None,
+            },
+        }
+    }
+
+    /// Render a single buffer, which is what pushes queued sounds and tracks to the renderer and
+    /// runs every effect in the graph over their audio.
+    fn render(audio_output: &mut AudioOutput<MockBackend>) {
+        let backend = audio_output
+            .manager
+            .as_mut()
+            .expect("the mock manager was created")
+            .backend_mut();
+
+        backend.on_start_processing();
+        backend.process();
+    }
+
+    /// An effect recording whether any audio reached it.
+    struct Probe(Arc<AtomicBool>);
+
+    impl Probe {
+        fn new() -> Self {
+            Self(Arc::new(AtomicBool::new(false)))
+        }
+    }
+
+    impl Effect for Probe {
+        fn process(&mut self, input: &mut [Frame], _dt: f64, _info: &Info) {
+            if input.iter().any(|frame| *frame != Frame::ZERO) {
+                self.0.store(true, Ordering::Relaxed);
+            }
+        }
+    }
+
+    impl AudioEffect for Probe {
+        type Handle = Arc<AtomicBool>;
+
+        fn build_effect(self) -> (Box<dyn Effect>, Self::Handle) {
+            let heard = self.0.clone();
+
+            (Box::new(self), heard)
+        }
+    }
+
+    /// The channel that `AudioChannel<Audio>` plays on.
+    fn main_channel() -> Channel {
+        Channel::Typed(TypeId::of::<Audio>())
+    }
+
+    /// Number of sub-tracks of the given channel's own track.
+    fn channel_sub_tracks(audio_output: &AudioOutput<MockBackend>, channel: &Channel) -> usize {
+        audio_output
+            .channel_tracks
+            .get(channel)
+            .expect("the channel has a track")
+            .num_sub_tracks()
+    }
+
+    /// Number of tracks attached directly to the manager.
+    fn manager_sub_tracks(audio_output: &AudioOutput<MockBackend>) -> usize {
+        audio_output
+            .manager
+            .as_ref()
+            .expect("the mock manager was created")
+            .num_sub_tracks()
+    }
+
+    /// Play a single sound on `AudioChannel<Audio>`, configured by `configure`.
+    fn play_on_main_channel(
+        audio_output: &mut AudioOutput<MockBackend>,
+        configure: impl FnOnce(&mut PlayAudioCommand),
+    ) {
+        let mut sources = Assets::<AudioSource>::default();
+        let mut instances = Assets::<AudioInstance>::default();
+        let source: Handle<AudioSource> = Handle::Uuid(Uuid::new_v4(), PhantomData);
+        let _ = sources.insert(&source, audio_source());
+
+        let channel = AudioChannel::<Audio>::default();
+        configure(&mut channel.play(source));
+
+        audio_output.play_channel(&sources, &channel, &mut instances);
     }
 
     #[test]
@@ -588,6 +725,78 @@ mod test {
     }
 
     #[test]
+    fn instance_effects_run_on_a_sub_track_of_the_channel_track() {
+        let mut audio_output = audio_output();
+        audio_output.create_channel_track(
+            main_channel(),
+            AudioTrack::new().with_effect(ReverbBuilder::new()),
+        );
+
+        play_on_main_channel(&mut audio_output, |command| {
+            command.with_effect(FilterBuilder::new());
+        });
+
+        assert_eq!(audio_output.instances[&main_channel()].len(), 1);
+        assert_eq!(audio_output.instance_tracks.len(), 1);
+        assert_eq!(channel_sub_tracks(&audio_output, &main_channel()), 1);
+        // The channel's own track is the only one hanging off the manager.
+        assert_eq!(manager_sub_tracks(&audio_output), 1);
+    }
+
+    #[test]
+    fn a_sound_with_its_own_effects_is_processed_by_the_channel_effects_as_well() {
+        let mut audio_output = audio_output();
+        let mut track = AudioTrack::new();
+        let channel_probe = track.add_effect(Probe::new());
+        audio_output.create_channel_track(main_channel(), track);
+
+        let mut instance_probe = None;
+        play_on_main_channel(&mut audio_output, |command| {
+            instance_probe = Some(command.add_effect(Probe::new()));
+        });
+        render(&mut audio_output);
+
+        assert!(
+            instance_probe.unwrap().load(Ordering::Relaxed),
+            "the sound did not reach its own effects"
+        );
+        assert!(
+            channel_probe.load(Ordering::Relaxed),
+            "the sound bypassed the channel's effects"
+        );
+    }
+
+    #[test]
+    fn instance_effects_run_on_a_manager_track_without_a_channel_track() {
+        let mut audio_output = audio_output();
+
+        play_on_main_channel(&mut audio_output, |command| {
+            command.with_effect(FilterBuilder::new());
+        });
+
+        assert_eq!(audio_output.instances[&main_channel()].len(), 1);
+        assert_eq!(audio_output.instance_tracks.len(), 1);
+        assert!(audio_output.channel_tracks.is_empty());
+        assert_eq!(manager_sub_tracks(&audio_output), 1);
+    }
+
+    #[test]
+    fn a_sound_without_effects_plays_on_the_channel_track_itself() {
+        let mut audio_output = audio_output();
+        audio_output.create_channel_track(
+            main_channel(),
+            AudioTrack::new().with_effect(ReverbBuilder::new()),
+        );
+
+        play_on_main_channel(&mut audio_output, |_| {});
+
+        assert_eq!(audio_output.instances[&main_channel()].len(), 1);
+        assert!(audio_output.instance_tracks.is_empty());
+        assert_eq!(channel_sub_tracks(&audio_output, &main_channel()), 0);
+        assert_eq!(manager_sub_tracks(&audio_output), 1);
+    }
+
+    #[test]
     fn keeps_order_of_commands_to_retry() {
         // we only need this app to conveniently get a assets collection for `AudioSource`...
         let mut app = App::new();
@@ -601,13 +810,7 @@ mod test {
             .remove_resource::<Assets<AudioInstance>>()
             .unwrap();
 
-        let mut audio_output = AudioOutput {
-            manager: AudioManager::new(AudioManagerSettings::<MockBackend>::default()).ok(),
-            instances: HashMap::default(),
-            channels: HashMap::default(),
-            channel_tracks: HashMap::default(),
-            instance_tracks: HashMap::default(),
-        };
+        let mut audio_output = audio_output();
         let audio_handle_one: Handle<AudioSource> =
             Handle::<AudioSource>::Uuid(Uuid::new_v4(), PhantomData);
         let audio_handle_two: Handle<AudioSource> =
@@ -649,13 +852,7 @@ mod test {
             .remove_resource::<Assets<AudioInstance>>()
             .unwrap();
 
-        let mut audio_output = AudioOutput {
-            manager: AudioManager::new(AudioManagerSettings::<MockBackend>::default()).ok(),
-            instances: HashMap::default(),
-            channels: HashMap::default(),
-            channel_tracks: HashMap::default(),
-            instance_tracks: HashMap::default(),
-        };
+        let mut audio_output = audio_output();
         let audio_handle_one: Handle<AudioSource> =
             Handle::<AudioSource>::Uuid(Uuid::new_v4(), PhantomData);
         let audio_handle_two: Handle<AudioSource> =

--- a/src/audio_output.rs
+++ b/src/audio_output.rs
@@ -269,14 +269,11 @@ impl<B: Backend> AudioOutput<B> {
         partial_sound_settings.apply(&mut sound);
 
         // Determine where to play the sound based on per-instance and channel tracks
-        let instance_track = partial_sound_settings
-            .track
-            .as_ref()
-            .and_then(|shared| shared.lock().take());
+        let instance_track = partial_sound_settings.track.lock().take();
 
         let sound_handle = if let Some(track) = instance_track {
             // Per-instance effects: create a sub-track for this instance
-            match self.add_instance_track(channel, track) {
+            match self.add_instance_track(channel, *track) {
                 Ok(mut track_handle) => {
                     let result = track_handle.play(sound);
                     if result.is_ok() {

--- a/src/audio_output.rs
+++ b/src/audio_output.rs
@@ -8,7 +8,7 @@ use crate::backend_settings::AudioSettings;
 use crate::channel::dynamic::DynamicAudioChannels;
 use crate::channel::typed::AudioChannel;
 use crate::channel::{Channel, ChannelState};
-use crate::effect::AudioTrack;
+use crate::effect::{AudioTrack, DEFAULT_EFFECT_TAIL};
 use crate::instance::AudioInstance;
 use crate::source::AudioSource;
 use bevy::asset::{AssetId, Assets, Handle};
@@ -17,11 +17,53 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::system::{NonSend, Res};
 use bevy::ecs::world::{FromWorld, World};
 use bevy::log::warn;
+use bevy::platform::time::Instant;
 use kira::backend::{Backend, DefaultBackend};
 use kira::track::TrackHandle;
 use kira::{AudioManager, Panning};
 use kira::{Decibels, PlaybackRate};
 use std::collections::HashMap;
+use std::time::Duration;
+
+/// The sub-track carrying one sound instance's effects.
+///
+/// Kira tears a track out of the audio graph as soon as its handle is dropped, without waiting for
+/// anything still ringing on it to fade. Dropping the handle the moment playback stops would
+/// therefore silence reverb and delay tails instead of letting them ring out, so the handle is held
+/// for a while longer.
+struct InstanceTrack {
+    /// Held only for its `Drop`, which is what removes the sub-track from the audio graph.
+    #[expect(dead_code, reason = "kept alive so that dropping it removes the track")]
+    handle: TrackHandle,
+    /// How long to hold on after the sound stops.
+    tail: Duration,
+    /// When the tail runs out. `None` while the sound is still playing.
+    ///
+    /// Effects ring out in wall-clock time, so this deadline is taken against
+    /// [`Instant`] rather than any of Bevy's clocks, which can be paused, scaled or missing
+    /// entirely when [`TimePlugin`](bevy::time::TimePlugin) is not part of the app.
+    expires_at: Option<Instant>,
+}
+
+impl InstanceTrack {
+    fn new(handle: TrackHandle, tail: Duration) -> Self {
+        Self {
+            handle,
+            tail,
+            expires_at: None,
+        }
+    }
+
+    /// Start the countdown after which the track and its effects are torn down.
+    fn start_tail(&mut self, now: Instant) {
+        self.expires_at.get_or_insert(now + self.tail);
+    }
+
+    /// Report whether the track should be kept at `now`.
+    fn keep_alive(&self, now: Instant) -> bool {
+        self.expires_at.is_none_or(|expires_at| now < expires_at)
+    }
+}
 
 /// Non-send resource that acts as audio output
 ///
@@ -32,7 +74,7 @@ pub(crate) struct AudioOutput<B: Backend = DefaultBackend> {
     instances: HashMap<Channel, Vec<Handle<AudioInstance>>>,
     channels: HashMap<Channel, ChannelState>,
     channel_tracks: HashMap<Channel, TrackHandle>,
-    instance_tracks: HashMap<AssetId<AudioInstance>, TrackHandle>,
+    instance_tracks: HashMap<AssetId<AudioInstance>, InstanceTrack>,
 }
 
 impl FromWorld for AudioOutput {
@@ -238,8 +280,11 @@ impl<B: Backend> AudioOutput<B> {
                 Ok(mut track_handle) => {
                     let result = track_handle.play(sound);
                     if result.is_ok() {
+                        let tail = partial_sound_settings
+                            .effect_tail
+                            .unwrap_or(DEFAULT_EFFECT_TAIL);
                         self.instance_tracks
-                            .insert(instance_handle.id(), track_handle);
+                            .insert(instance_handle.id(), InstanceTrack::new(track_handle, tail));
                     }
                     result
                 }
@@ -420,22 +465,27 @@ impl<B: Backend> AudioOutput<B> {
     }
 
     pub(crate) fn cleanup_stopped_instances(&mut self, instances: &mut Assets<AudioInstance>) {
+        let now = Instant::now();
+
         for handles in self.instances.values_mut() {
             handles.retain(|handle| {
-                if let Some(instance) = instances.get(handle) {
-                    if instance.handle.state() == kira::sound::PlaybackState::Stopped {
-                        // Drop the per-instance track handle (kira will clean up the sub-track)
-                        self.instance_tracks.remove(&handle.id());
-                        false
-                    } else {
-                        true
+                let stopped = instances.get(handle).is_none_or(|instance| {
+                    instance.handle.state() == kira::sound::PlaybackState::Stopped
+                });
+                if stopped {
+                    // Let the effects on this instance's track ring out before tearing it down.
+                    if let Some(track) = self.instance_tracks.get_mut(&handle.id()) {
+                        track.start_tail(now);
                     }
-                } else {
-                    self.instance_tracks.remove(&handle.id());
-                    false
                 }
+
+                !stopped
             });
         }
+
+        // Dropping the handle is what removes the sub-track from kira's audio graph.
+        self.instance_tracks
+            .retain(|_, track| track.keep_alive(now));
     }
 }
 
@@ -499,7 +549,43 @@ mod test {
     use bevy::prelude::*;
     use kira::AudioManagerSettings;
     use kira::backend::mock::MockBackend;
+    use kira::track::TrackBuilder;
     use uuid::Uuid;
+
+    fn instance_track(tail: Duration) -> InstanceTrack {
+        let mut manager =
+            AudioManager::new(AudioManagerSettings::<MockBackend>::default()).unwrap();
+
+        InstanceTrack::new(manager.add_sub_track(TrackBuilder::new()).unwrap(), tail)
+    }
+
+    #[test]
+    fn instance_track_is_kept_while_its_sound_plays() {
+        let track = instance_track(Duration::from_millis(100));
+        let now = Instant::now();
+
+        assert!(track.keep_alive(now + Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn instance_track_outlives_its_sound_by_the_effect_tail() {
+        let mut track = instance_track(Duration::from_millis(100));
+        let now = Instant::now();
+        track.start_tail(now);
+
+        assert!(track.keep_alive(now + Duration::from_millis(60)));
+        assert!(track.keep_alive(now + Duration::from_millis(99)));
+        assert!(!track.keep_alive(now + Duration::from_millis(100)));
+    }
+
+    #[test]
+    fn a_zero_effect_tail_drops_the_instance_track_right_away() {
+        let mut track = instance_track(Duration::ZERO);
+        let now = Instant::now();
+        track.start_tail(now);
+
+        assert!(!track.keep_alive(now));
+    }
 
     #[test]
     fn keeps_order_of_commands_to_retry() {

--- a/src/backend_settings.rs
+++ b/src/backend_settings.rs
@@ -1,6 +1,6 @@
 use bevy::ecs::resource::Resource;
 use bevy::utils::default;
-use kira::{AudioManagerSettings, DefaultBackend, track::MainTrackBuilder};
+use kira::{AudioManagerSettings, Capacities, DefaultBackend, track::MainTrackBuilder};
 
 /// This resource is used to configure the audio backend at creation
 ///
@@ -8,14 +8,17 @@ use kira::{AudioManagerSettings, DefaultBackend, track::MainTrackBuilder};
 /// consumed by it. Settings cannot be changed at run-time!
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AudioSettings {
-    /// The maximum number of sounds that can be playing at a time.
+    /// The maximum number of sounds that can play on the main track; channel tracks set their own.
     pub sound_capacity: usize,
+    /// The maximum number of sub-tracks on the main track; channel tracks set their own.
+    pub sub_track_capacity: usize,
 }
 
 impl Default for AudioSettings {
     fn default() -> Self {
         Self {
             sound_capacity: 128,
+            sub_track_capacity: 128,
         }
     }
 }
@@ -23,6 +26,10 @@ impl Default for AudioSettings {
 impl From<AudioSettings> for AudioManagerSettings<DefaultBackend> {
     fn from(settings: AudioSettings) -> Self {
         AudioManagerSettings {
+            capacities: Capacities {
+                sub_track_capacity: settings.sub_track_capacity,
+                ..default()
+            },
             main_track_builder: MainTrackBuilder::new().sound_capacity(settings.sound_capacity),
             ..default()
         }

--- a/src/effect.rs
+++ b/src/effect.rs
@@ -169,6 +169,11 @@ impl AudioTrack {
     }
 
     /// Set the maximum number of sub-tracks this track can hold.
+    ///
+    /// Every sound played on this channel with per-instance effects (see
+    /// [`add_effect`](crate::PlayAudioCommand::add_effect)) runs on a sub-track of this one and
+    /// takes a slot for as long as it plays, plus its
+    /// [effect tail](crate::PlayAudioCommand::with_effect_tail).
     #[must_use = "This method consumes self and returns a modified AudioTrack, so the return value should be used"]
     pub fn sub_track_capacity(self, capacity: usize) -> Self {
         Self(self.0.sub_track_capacity(capacity))

--- a/src/effect.rs
+++ b/src/effect.rs
@@ -22,6 +22,11 @@
 //! }
 //! ```
 //!
+//! Effects added to a single sound run on a track of that sound's own. Reverb and delay keep
+//! sounding after their input has gone quiet, so that track outlives the sound by
+//! [`DEFAULT_EFFECT_TAIL`]; see
+//! [`with_effect_tail`](crate::PlayAudioCommand::with_effect_tail) to change how long.
+//!
 //! # Custom effects
 //!
 //! Implement [`Effect`] to process audio frames yourself, then implement [`AudioEffect`] for a
@@ -68,6 +73,15 @@ pub use kira::effect::filter::{FilterBuilder, FilterMode};
 pub use kira::effect::panning_control::PanningControlBuilder;
 pub use kira::effect::reverb::ReverbBuilder;
 pub use kira::effect::volume_control::VolumeControlBuilder;
+
+/// How long a sound's effects keep running after the sound itself has stopped.
+///
+/// Effects like reverb and delay go on producing sound after their input has gone quiet. A sound
+/// with per-instance effects plays on its own track, and tearing that track down the moment the
+/// sound ends would cut those tails off mid-ring. The track is therefore kept for this long
+/// afterwards. Override it per sound with
+/// [`with_effect_tail`](crate::PlayAudioCommand::with_effect_tail).
+pub const DEFAULT_EFFECT_TAIL: Duration = Duration::from_secs(2);
 
 /// Something that can be added to an audio track as an effect.
 ///

--- a/src/effect.rs
+++ b/src/effect.rs
@@ -1,0 +1,432 @@
+//! Audio effects
+//!
+//! Effects modify the audio signal of a single sound instance or of a whole channel.
+//!
+//! Add an effect to one sound with [`PlayAudioCommand::add_effect`](crate::PlayAudioCommand::add_effect),
+//! or to an entire channel by building an [`AudioTrack`] and passing it to
+//! [`add_audio_channel_with_track`](crate::AudioApp::add_audio_channel_with_track).
+//!
+//! Every effect is configured through a builder. Adding it returns a handle that controls the
+//! effect while it plays. All handle setters take an [`AudioTween`] describing how the change is
+//! interpolated, just like the rest of this crate's API.
+//!
+//! ```no_run
+//! # use bevy::prelude::*;
+//! # use bevy_kira_audio::prelude::*;
+//!
+//! fn play(audio: Res<Audio>, asset_server: Res<AssetServer>) {
+//!     audio
+//!         .play(asset_server.load("sounds/loop.ogg"))
+//!         .with_effect(FilterBuilder::new().mode(FilterMode::LowPass).cutoff(300.0))
+//!         .looped();
+//! }
+//! ```
+//!
+//! # Custom effects
+//!
+//! Implement [`Effect`] to process audio frames yourself, then implement [`AudioEffect`] for a
+//! builder that creates it. Your builder can then be used anywhere the built-in ones are.
+//!
+//! ```
+//! use bevy_kira_audio::prelude::*;
+//!
+//! /// Silences the right channel.
+//! struct LeftOnly;
+//!
+//! impl Effect for LeftOnly {
+//!     fn process(&mut self, input: &mut [Frame], _dt: f64, _info: &Info) {
+//!         for frame in input {
+//!             frame.right = 0.0;
+//!         }
+//!     }
+//! }
+//!
+//! struct LeftOnlyBuilder;
+//!
+//! impl AudioEffect for LeftOnlyBuilder {
+//!     type Handle = ();
+//!
+//!     fn build_effect(self) -> (Box<dyn Effect>, Self::Handle) {
+//!         (Box::new(LeftOnly), ())
+//!     }
+//! }
+//! ```
+
+use crate::audio::AudioTween;
+use kira::effect::EffectBuilder as KiraEffectBuilder;
+use kira::track::TrackBuilder;
+use std::time::Duration;
+
+pub use kira::effect::Effect;
+pub use kira::info::Info;
+pub use kira::{Decibels, Frame, Mix, Panning};
+
+pub use kira::effect::compressor::CompressorBuilder;
+pub use kira::effect::distortion::{DistortionBuilder, DistortionKind};
+pub use kira::effect::eq_filter::{EqFilterBuilder, EqFilterKind};
+pub use kira::effect::filter::{FilterBuilder, FilterMode};
+pub use kira::effect::panning_control::PanningControlBuilder;
+pub use kira::effect::reverb::ReverbBuilder;
+pub use kira::effect::volume_control::VolumeControlBuilder;
+
+/// Something that can be added to an audio track as an effect.
+///
+/// This is implemented for every built-in effect builder. Implement it for your own type to use a
+/// custom [`Effect`] with this plugin (see the [module documentation](self#custom-effects)).
+pub trait AudioEffect {
+    /// Handle used to control the effect while it is running.
+    ///
+    /// Use `()` if the effect has nothing to control at runtime.
+    type Handle;
+
+    /// Build the effect together with a handle to control it.
+    fn build_effect(self) -> (Box<dyn Effect>, Self::Handle);
+}
+
+/// A track that sounds are played on, carrying a chain of effects.
+///
+/// Pass it to [`add_audio_channel_with_track`](crate::AudioApp::add_audio_channel_with_track) to
+/// apply its effects to every sound played on that channel.
+///
+/// ```no_run
+/// use bevy::prelude::*;
+/// use bevy_kira_audio::prelude::*;
+///
+/// #[derive(Resource)]
+/// struct MusicChannel;
+///
+/// fn main() {
+///     let mut track = AudioTrack::new();
+///     let _reverb = track.add_effect(ReverbBuilder::new());
+///
+///     App::new()
+///         .add_plugins((DefaultPlugins, AudioPlugin))
+///         .add_audio_channel_with_track::<MusicChannel>(track)
+///         .run();
+/// }
+/// ```
+pub struct AudioTrack(TrackBuilder);
+
+impl AudioTrack {
+    /// Create a new track with no effects.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(TrackBuilder::new())
+    }
+
+    /// Create the track carrying a single sound instance's own effects.
+    ///
+    /// Such a track hosts exactly the one sound: nesting anything under an instance
+    /// track fails with `ResourceLimitReached`.
+    pub(crate) fn for_instance() -> Self {
+        Self(TrackBuilder::new().sound_capacity(1).sub_track_capacity(0))
+    }
+
+    /// Add an effect to this track and return its handle for runtime control.
+    pub fn add_effect<E: AudioEffect>(&mut self, effect: E) -> E::Handle {
+        let (built, handle) = effect.build_effect();
+        self.0.add_built_effect(built);
+
+        handle
+    }
+
+    /// Add an effect to this track, discarding its handle.
+    ///
+    /// Use [`add_effect`](Self::add_effect) if you need to control the effect at runtime.
+    #[must_use = "This method consumes self and returns a modified AudioTrack, so the return value should be used"]
+    pub fn with_effect<E: AudioEffect>(mut self, effect: E) -> Self {
+        self.add_effect(effect);
+
+        self
+    }
+
+    /// Set the volume of this track in Decibels.
+    #[must_use = "This method consumes self and returns a modified AudioTrack, so the return value should be used"]
+    pub fn volume(self, volume: impl Into<Decibels>) -> Self {
+        let volume: Decibels = volume.into();
+
+        Self(self.0.volume(volume))
+    }
+
+    /// Set the maximum number of sounds that can play on this track at a time.
+    #[must_use = "This method consumes self and returns a modified AudioTrack, so the return value should be used"]
+    pub fn sound_capacity(self, capacity: usize) -> Self {
+        Self(self.0.sound_capacity(capacity))
+    }
+
+    /// Set the maximum number of sub-tracks this track can hold.
+    #[must_use = "This method consumes self and returns a modified AudioTrack, so the return value should be used"]
+    pub fn sub_track_capacity(self, capacity: usize) -> Self {
+        Self(self.0.sub_track_capacity(capacity))
+    }
+
+    /// Keep the track alive until all sounds on it have finished playing.
+    #[must_use = "This method consumes self and returns a modified AudioTrack, so the return value should be used"]
+    pub fn persist_until_sounds_finish(self, persist: bool) -> Self {
+        Self(self.0.persist_until_sounds_finish(persist))
+    }
+
+    pub(crate) fn into_inner(self) -> TrackBuilder {
+        self.0
+    }
+}
+
+impl Default for AudioTrack {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Adapter handing an already built effect to Kira's builder APIs.
+struct PreBuilt(Box<dyn Effect>);
+
+impl KiraEffectBuilder for PreBuilt {
+    type Handle = ();
+
+    fn build(self) -> (Box<dyn Effect>, Self::Handle) {
+        (self.0, ())
+    }
+}
+
+/// Configures a delay effect, adding echoes to a sound.
+///
+/// Effects can be added to the feedback loop, so that every echo is processed by them.
+pub struct DelayBuilder(kira::effect::delay::DelayBuilder);
+
+impl DelayBuilder {
+    /// Create a new `DelayBuilder` with the default settings.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(kira::effect::delay::DelayBuilder::new())
+    }
+
+    /// Set the amount of time the input audio is delayed by.
+    #[must_use = "This method consumes self and returns a modified DelayBuilder, so the return value should be used"]
+    pub fn delay_time(self, delay_time: Duration) -> Self {
+        Self(self.0.delay_time(delay_time))
+    }
+
+    /// Set the amount of feedback in Decibels.
+    #[must_use = "This method consumes self and returns a modified DelayBuilder, so the return value should be used"]
+    pub fn feedback(self, feedback: impl Into<Decibels>) -> Self {
+        let feedback: Decibels = feedback.into();
+
+        Self(self.0.feedback(feedback))
+    }
+
+    /// Set how much dry (unprocessed) signal is blended with the wet (processed) signal.
+    #[must_use = "This method consumes self and returns a modified DelayBuilder, so the return value should be used"]
+    pub fn mix(self, mix: impl Into<Mix>) -> Self {
+        let mix: Mix = mix.into();
+
+        Self(self.0.mix(mix))
+    }
+
+    /// Add an effect to the feedback loop and return its handle for runtime control.
+    pub fn add_feedback_effect<E: AudioEffect>(&mut self, effect: E) -> E::Handle {
+        let (built, handle) = effect.build_effect();
+        self.0.add_feedback_effect(PreBuilt(built));
+
+        handle
+    }
+
+    /// Add an effect to the feedback loop, discarding its handle.
+    ///
+    /// Use [`add_feedback_effect`](Self::add_feedback_effect) if you need to control the effect at
+    /// runtime.
+    #[must_use = "This method consumes self and returns a modified DelayBuilder, so the return value should be used"]
+    pub fn with_feedback_effect<E: AudioEffect>(mut self, effect: E) -> Self {
+        self.add_feedback_effect(effect);
+
+        self
+    }
+}
+
+impl Default for DelayBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AudioEffect for DelayBuilder {
+    type Handle = DelayHandle;
+
+    fn build_effect(self) -> (Box<dyn Effect>, Self::Handle) {
+        let (effect, handle) = KiraEffectBuilder::build(self.0);
+
+        (effect, DelayHandle(handle))
+    }
+}
+
+/// Define a handle wrapping a Kira effect handle, forwarding its tweened setters.
+macro_rules! effect_handle {
+    (
+        $(#[$handle_doc:meta])*
+        $name:ident($inner:ty) {
+            $(
+                $(#[$setter_doc:meta])*
+                $setter:ident($param:ident: $public:ty => $concrete:ty);
+            )*
+        }
+    ) => {
+        $(#[$handle_doc])*
+        #[derive(Debug)]
+        pub struct $name($inner);
+
+        impl $name {
+            $(
+                $(#[$setter_doc])*
+                pub fn $setter(&mut self, $param: $public, tween: AudioTween) {
+                    let $param: $concrete = $param.into();
+                    self.0.$setter($param, tween.into());
+                }
+            )*
+        }
+    };
+}
+
+effect_handle! {
+    /// Controls a filter effect.
+    FilterHandle(kira::effect::filter::FilterHandle) {
+        /// Set the cutoff frequency of the filter (in hertz).
+        set_cutoff(cutoff: f64 => f64);
+        /// Set the resonance of the filter.
+        set_resonance(resonance: f64 => f64);
+        /// Set how much dry (unprocessed) signal is blended with the wet (processed) signal.
+        set_mix(mix: impl Into<Mix> => Mix);
+    }
+}
+
+impl FilterHandle {
+    /// Set the frequencies that the filter will remove.
+    pub fn set_mode(&mut self, mode: FilterMode) {
+        self.0.set_mode(mode);
+    }
+}
+
+effect_handle! {
+    /// Controls a reverb effect.
+    ReverbHandle(kira::effect::reverb::ReverbHandle) {
+        /// Set how much the room reverberates.
+        ///
+        /// A higher value results in a bigger sounding room. `1.0` gives an infinitely
+        /// reverberating room.
+        set_feedback(feedback: f64 => f64);
+        /// Set how quickly high frequencies disappear from the reverberation.
+        set_damping(damping: f64 => f64);
+        /// Set the stereo width of the reverb effect (`0.0` being fully mono, `1.0` fully stereo).
+        set_stereo_width(stereo_width: f64 => f64);
+        /// Set how much dry (unprocessed) signal is blended with the wet (processed) signal.
+        set_mix(mix: impl Into<Mix> => Mix);
+    }
+}
+
+effect_handle! {
+    /// Controls a delay effect.
+    DelayHandle(kira::effect::delay::DelayHandle) {
+        /// Set the amount of feedback in Decibels.
+        set_feedback(feedback: impl Into<Decibels> => Decibels);
+        /// Set how much dry (unprocessed) signal is blended with the wet (processed) signal.
+        set_mix(mix: impl Into<Mix> => Mix);
+    }
+}
+
+effect_handle! {
+    /// Controls a distortion effect.
+    DistortionHandle(kira::effect::distortion::DistortionHandle) {
+        /// Set how much the input signal is driven in Decibels.
+        set_drive(drive: impl Into<Decibels> => Decibels);
+        /// Set how much dry (unprocessed) signal is blended with the wet (processed) signal.
+        set_mix(mix: impl Into<Mix> => Mix);
+    }
+}
+
+impl DistortionHandle {
+    /// Set the kind of distortion that is applied.
+    pub fn set_kind(&mut self, kind: DistortionKind) {
+        self.0.set_kind(kind);
+    }
+}
+
+effect_handle! {
+    /// Controls a compressor effect.
+    CompressorHandle(kira::effect::compressor::CompressorHandle) {
+        /// Set the volume above which volume will be decreased (in Decibels).
+        set_threshold(threshold: f64 => f64);
+        /// Set how much the signal will be compressed once it exceeds the threshold.
+        set_ratio(ratio: f64 => f64);
+        /// Set how quickly the compressor kicks in once the input exceeds the threshold.
+        set_attack_duration(attack_duration: Duration => Duration);
+        /// Set how quickly the compressor stops once the input falls below the threshold.
+        set_release_duration(release_duration: Duration => Duration);
+        /// Set the volume applied to the signal after compression (in Decibels).
+        set_makeup_gain(makeup_gain: impl Into<Decibels> => Decibels);
+        /// Set how much dry (unprocessed) signal is blended with the wet (processed) signal.
+        set_mix(mix: impl Into<Mix> => Mix);
+    }
+}
+
+effect_handle! {
+    /// Controls an EQ filter effect.
+    EqFilterHandle(kira::effect::eq_filter::EqFilterHandle) {
+        /// Set the frequency the filter is centered on (in hertz).
+        set_frequency(frequency: f64 => f64);
+        /// Set the volume adjustment applied to the frequency range (in Decibels).
+        set_gain(gain: impl Into<Decibels> => Decibels);
+        /// Set the width of the frequency range that is adjusted.
+        set_q(q: f64 => f64);
+    }
+}
+
+impl EqFilterHandle {
+    /// Set the shape of the frequency adjustment curve.
+    pub fn set_kind(&mut self, kind: EqFilterKind) {
+        self.0.set_kind(kind);
+    }
+}
+
+effect_handle! {
+    /// Controls a volume control effect.
+    VolumeControlHandle(kira::effect::volume_control::VolumeControlHandle) {
+        /// Set the volume in Decibels.
+        set_volume(volume: impl Into<Decibels> => Decibels);
+    }
+}
+
+effect_handle! {
+    /// Controls a panning control effect.
+    PanningControlHandle(kira::effect::panning_control::PanningControlHandle) {
+        /// Set the panning.
+        ///
+        /// The default value is `0.0`. Values up to `1.0` pan to the right, values down to `-1.0`
+        /// pan to the left.
+        set_panning(panning: f32 => Panning);
+    }
+}
+
+/// Implement [`AudioEffect`] for Kira's effect builders, wrapping the handles they return.
+macro_rules! impl_audio_effect {
+    ($($builder:ty => $handle:ident),* $(,)?) => {
+        $(
+            impl AudioEffect for $builder {
+                type Handle = $handle;
+
+                fn build_effect(self) -> (Box<dyn Effect>, Self::Handle) {
+                    let (effect, handle) = KiraEffectBuilder::build(self);
+
+                    (effect, $handle(handle))
+                }
+            }
+        )*
+    };
+}
+
+impl_audio_effect! {
+    CompressorBuilder => CompressorHandle,
+    DistortionBuilder => DistortionHandle,
+    EqFilterBuilder => EqFilterHandle,
+    FilterBuilder => FilterHandle,
+    PanningControlBuilder => PanningControlHandle,
+    ReverbBuilder => ReverbHandle,
+    VolumeControlBuilder => VolumeControlHandle,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod audio;
 mod audio_output;
 mod backend_settings;
 mod channel;
+pub mod effect;
 mod instance;
 mod source;
 mod spatial;
@@ -50,6 +51,7 @@ pub use backend_settings::AudioSettings;
 use bevy::app::{PostUpdate, PreUpdate};
 use bevy::asset::AssetApp;
 pub use channel::AudioControl;
+pub use effect::{AudioEffect, AudioTrack};
 pub use source::AudioSource;
 pub use spatial::{
     DefaultSpatialRadius, SpatialAudioEmitter, SpatialAudioPlugin, SpatialAudioReceiver,
@@ -70,6 +72,14 @@ pub mod prelude {
     pub use crate::channel::dynamic::{DynamicAudioChannel, DynamicAudioChannels};
     #[doc(hidden)]
     pub use crate::channel::typed::AudioChannel;
+    #[doc(hidden)]
+    pub use crate::effect::{
+        AudioEffect, AudioTrack, CompressorBuilder, CompressorHandle, DelayBuilder, DelayHandle,
+        DistortionBuilder, DistortionHandle, DistortionKind, Effect, EqFilterBuilder,
+        EqFilterHandle, EqFilterKind, FilterBuilder, FilterHandle, FilterMode, Info, Mix,
+        PanningControlBuilder, PanningControlHandle, ReverbBuilder, ReverbHandle,
+        VolumeControlBuilder, VolumeControlHandle,
+    };
     #[doc(hidden)]
     pub use crate::instance::{AudioInstance, AudioInstanceAssetsExt};
     #[doc(hidden)]


### PR DESCRIPTION
This PR makes it possible to use any of the effects available in Kira Audio. I’ve also added a few examples, with `multiple_effects_channel` serving as an all-in-one interactive demo that gives a nice overview of what’s included. I’m already using this in my little project to muffle the music while the game is paused.

Let me know what you think.

Fixes #127